### PR TITLE
Fix #93

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,15 @@
-pop-gtk-theme (3.0.2) UNRELEASED; urgency=medium
+pop-gtk-theme (3.0.3) artful; urgency=medium
+
+  * Fix bug with animating Overview. GH:pop-os/gtk-theme#93
+
+ -- Ian Santopietro <ian@system76.com>  Tue, 16 Jan 2018 11:52:04 -0700
+
+pop-gtk-theme (3.0.2) artful; urgency=medium
 
   * Ensure better headerbar size in -slim. 
-  * Make sure titlebuttons are all round.
+  * Make sure titlebuttons are all round. 
 
- -- Ian Santopietro <ian@system76.com>  Tue, 26 Dec 2017 14:46:40 -0700
+ -- Ian Santopietro <ian@system76.com>  Tue, 16 Jan 2018 11:51:15 -0700
 
 pop-gtk-theme (3.0.1) artful; urgency=medium
 

--- a/src/gnome-shell/common/sass/widgets/_topbar.scss
+++ b/src/gnome-shell/common/sass/widgets/_topbar.scss
@@ -14,7 +14,7 @@
     box-shadow: none;
   }
 
-  &:overview,
+  //&:overview, // <- this breaks the overview transition on the primary display. See https://github.com/pop-os/gtk-theme/issues/93
   &.unlock-screen,
   &.login-screen,
   &.lock-screen {


### PR DESCRIPTION
This PR fixes #93 and allows the overview to properly animate correctly.

Testing: 
1. Before installing update, press Super with windows open. On the primary display, the windows should not animate into position. 
2. Install update
3. Press Super. Windows should now slide into position.

Note: checking colors shouldn't be necessary since this is a one-line commit.