### PR TITLE
Make the dark background color more neutral

### DIFF
--- a/src/gtk-3.0/3.22/sass/_colors.scss
+++ b/src/gtk-3.0/3.22/sass/_colors.scss
@@ -42,11 +42,11 @@ $inverse_track_color:                 rgba($white, 0.3);
 $inverse_divider_color:               rgba($white, 0.12);
 
 // Background colors
-$bg_color:         if($variant == 'light', $grey_50, darken($brown_700, 5%));
-$base_color:       if($variant == 'light', $white,   darken($brown_700, 7%));
+$bg_color:         if($variant == 'light', $grey_50, darken( mix($grey_700, $brown_700, 50%), 5%));
+$base_color:       if($variant == 'light', $white,   darken( mix($grey_700, $brown_700, 50%), 7%));
 $alt_base_color:   if($variant == 'light', lighten($grey_50, 0%),  mix($base_color, $bg_color, 50%));
-$lighter_bg_color: if($variant == 'light', lighten($grey_50, 0%),  $brown_700); //FIXME: lol
-$darker_bg_color:  if($variant == 'light', $grey_200, $brown_800);
+$lighter_bg_color: if($variant == 'light', lighten($grey_50, 0%),  mix($grey_700, $brown_700, 50%); //FIXME: lol
+$darker_bg_color:  if($variant == 'light', $grey_200, mix($grey_700, $brown_700, 50%));
 
 $titlebar_bg_color:          if($titlebar == 'dark',
                                 if($variant == 'light',


### PR DESCRIPTION
Makes the dark-variant main background colors more neutral to reduce the color-interference when working with color-sensitive apps in the dark theme. 

It does so in a way that is easy to tweak later on if we need to make it more- or less-neutral.