### PR TITLE
Improvements to the light background colors

### DIFF
--- a/src/gtk-3.0/3.22/sass/_color-palette.scss
+++ b/src/gtk-3.0/3.22/sass/_color-palette.scss
@@ -137,11 +137,11 @@ $brown_900: darken($brown_800, 16%);
 
 // Grey
 $grey_500: $medium_gray;
-$grey_400: lighten($grey_500, 9%);
-$grey_300: lighten($grey_400, 9%);
-$grey_200: lighten($grey_300, 9%);
-$grey_100: lighten($grey_200, 9%);
-$grey_50:  lighten($grey_100, 9%);
+$grey_400: #DEDEDE;
+$grey_300: #E6E6E6;
+$grey_200: #EDEDED;
+$grey_100: #F5F5F5;
+$grey_50:  #FBFBFB;
 $grey_600: darken($grey_500, 14%);
 $grey_700: darken($grey_600, 14%);
 $grey_800: darken($grey_700, 14%);

--- a/src/gtk-3.0/3.22/sass/_colors.scss
+++ b/src/gtk-3.0/3.22/sass/_colors.scss
@@ -42,11 +42,11 @@ $inverse_track_color:                 rgba($white, 0.3);
 $inverse_divider_color:               rgba($white, 0.12);
 
 // Background colors
-$bg_color:         if($variant == 'light', $grey_50, darken($brown_700, 5%));
-$base_color:       if($variant == 'light', $white,   darken($brown_700, 7%));
-$alt_base_color:   if($variant == 'light', lighten($grey_50, 0%),  mix($base_color, $bg_color, 50%));
-$lighter_bg_color: if($variant == 'light', lighten($grey_50, 0%),  $brown_700); //FIXME: lol
-$darker_bg_color:  if($variant == 'light', $grey_200, $brown_800);
+$bg_color:         if($variant == 'light', $grey_100, darken($brown_700, 5%));
+$base_color:       if($variant == 'light', lighten($grey_100, 2%),   darken($brown_700, 7%));
+$alt_base_color:   if($variant == 'light', $grey_200,  mix($base_color, $bg_color, 50%));
+$lighter_bg_color: if($variant == 'light', $grey_50,  $brown_700); //FIXME: lol
+$darker_bg_color:  if($variant == 'light', $grey_300, $brown_800);
 
 $titlebar_bg_color:          if($titlebar == 'dark',
                                 if($variant == 'light',


### PR DESCRIPTION
In the current Pop-gtk theme, many of the background colors are generated programmatically, and since they're so light to begin with, they end up being white. The creates a somewhat harsh experience when using the theme, and causes the panes of many apps to become the same color. 

This corrects this by hand-selecting several different light greys for use with the theme, and using those. 