### PR TITLE
Fix black separators

### DIFF
--- a/src/gtk-3.0/3.22/sass/widgets/_headerbar.scss
+++ b/src/gtk-3.0/3.22/sass/widgets/_headerbar.scss
@@ -32,8 +32,12 @@ headerbar {
   }
   
   separator {
-    background: none;
+    background-color: $titlebar_bg_color;
     margin: 0 $standard_padding;
+    
+    &:backdrop {
+      background-color: $inactive_titlebar_bg_color;
+    }
     
     &:first-child,
     &:last-child {
@@ -267,7 +271,7 @@ window.tiled-right {
   }
 
   > separator {
-    background: none;
+    background: $titlebar_bg_color;
     color: $titlebar_bg_color;
     border: none;
     padding: 0;


### PR DESCRIPTION
In applications with split headerbars (like Settings and Tweaks), the separator between the two has no background set, which causes it to appear black. This looks really bad.

This PR fixes this to ensure that the separators have good looking styling when they are present. It doesn't completely remove the visual separation between the two halves of the headerbar (because the headerbars still have shadows), but it does make them much less visible.