### PR TITLE
Added indentation to menu sub menu items

### DIFF
--- a/src/gnome-shell/3.18/sass/_extensions.scss
+++ b/src/gnome-shell/3.18/sass/_extensions.scss
@@ -1,3 +1,12 @@
+/* GSConnect */
+// Need to remvoe padding on GSconnect's first child. Otherwise the icons appear
+// stretched. See https://github.com/andyholmes/gnome-shell-extension-gsconnect/issues/44
+
+.aggregate-menu .popup-sub-menu .gsconnect-device-box :first-child {
+  padding: 0;
+  margin: 0;
+}
+
 /* Dash to Dock */
 
 #dashtodockContainer #dash {

--- a/src/gnome-shell/common/sass/widgets/_menu-popover.scss
+++ b/src/gnome-shell/common/sass/widgets/_menu-popover.scss
@@ -99,11 +99,19 @@
   app menu inside the main app window itself rather than the top bar
 */
 
-.aggregate-menu {
-  .popup-sub-menu .popup-menu-item {
-    &:ltr { 
-            padding-left: 20px; margin-left: 1.09em; }
-    &:rtl { 
-            padding-right: 20px; margin-right: 1.09em; }
-  }
+// .aggregate-menu {
+//   .popup-sub-menu .popup-menu-item {
+//     &:ltr { 
+//             padding-left: 20px; margin-left: 1.09em; }
+//     &:rtl { 
+//             padding-right: 20px; margin-right: 1.09em; }
+//   }
+// }
+
+.aggregate-menu .popup-sub-menu .popup-menu-item:ltr {
+  padding-left: 20px; margin-left: 1.09em;
+}
+
+.aggregate-menu .popup-sub-menu .popup-menu-item:rtl {
+  padding-right: 20px; margin-right: 1.09em;
 }

--- a/src/gnome-shell/common/sass/widgets/_menu-popover.scss
+++ b/src/gnome-shell/common/sass/widgets/_menu-popover.scss
@@ -98,3 +98,12 @@
 - odd thing for styling App menu when apparently not running under shell. Light Adwaita styled
   app menu inside the main app window itself rather than the top bar
 */
+
+.aggregate-menu {
+  .popup-sub-menu .popup-menu-item {
+    &:ltr { 
+            padding-left: 20px; margin-left: 1.09em; }
+    &:rtl { 
+            padding-right: 20px; margin-right: 1.09em; }
+  }
+}

--- a/src/gnome-shell/common/sass/widgets/_menu-popover.scss
+++ b/src/gnome-shell/common/sass/widgets/_menu-popover.scss
@@ -99,19 +99,11 @@
   app menu inside the main app window itself rather than the top bar
 */
 
-// .aggregate-menu {
-//   .popup-sub-menu .popup-menu-item {
-//     &:ltr { 
-//             padding-left: 20px; margin-left: 1.09em; }
-//     &:rtl { 
-//             padding-right: 20px; margin-right: 1.09em; }
-//   }
-// }
-
-.aggregate-menu .popup-sub-menu .popup-menu-item:ltr {
-  padding-left: 20px; margin-left: 1.09em;
-}
-
-.aggregate-menu .popup-sub-menu .popup-menu-item:rtl {
-  padding-right: 20px; margin-right: 1.09em;
+.aggregate-menu {
+  .popup-sub-menu .popup-menu-item :first-child {
+    &:ltr { 
+            padding-left: 20px; margin-left: 1.09em; }
+    &:rtl { 
+            padding-right: 20px; margin-right: 1.09em; }
+  }
 }

--- a/src/gnome-shell/common/sass/widgets/_menu-popover.scss
+++ b/src/gnome-shell/common/sass/widgets/_menu-popover.scss
@@ -102,8 +102,10 @@
 .aggregate-menu {
   .popup-sub-menu .popup-menu-item :first-child {
     &:ltr { 
-            padding-left: 20px; margin-left: 1.09em; }
+            padding-left: 20px; margin-left: 1.09em; 
+    }
     &:rtl { 
-            padding-right: 20px; margin-right: 1.09em; }
+            padding-right: 20px; margin-right: 1.09em; 
+    }
   }
 }


### PR DESCRIPTION
Add a 20px padding to each submenu item and a 1.09 em margin (taken from gnome-shell)

Tested on the latest 18.04 iso and the 17.10 on System76 Lemur. 

Fixes #136 