### PR TITLE
Text size

### DIFF
--- a/src/gtk-3.0/3.22/sass/apps/_elementary.scss
+++ b/src/gtk-3.0/3.22/sass/apps/_elementary.scss
@@ -55,7 +55,7 @@ button.back-button,
 }
 
 .h3 {
-  font-size: 11px;
+  font-size: 14px;
 }
 
 .h4,


### PR DESCRIPTION
The text size before was set hilariously tiny with the Fira Sans font.

After tweaking: 
![screenshot from 2018-04-06 15-55-43](https://user-images.githubusercontent.com/5883565/38445971-04ca6770-39b3-11e8-9bb0-183c75eb3982.png)

Fixes pop-os/shop#64