### PR TITLE
Make Gtk2 tooltips stand out. Fixes #155

### DIFF
--- a/src/gtk-2.0/gtkrc-dark.in
+++ b/src/gtk-2.0/gtkrc-dark.in
@@ -21,6 +21,8 @@ gtk-color-scheme = "selected_fg_color:#FFFFFF\nselected_bg_color:#2C8691"
 gtk-color-scheme = "titlebar_fg_color:#F6F6F6\ntitlebar_bg_color:#3b3633"
 # Links
 gtk-color-scheme = "link_color:#2C8691\nvisited_link_color:#E040FB"
+# Tooltips
+gtk-color-scheme = "tooltip_bg_color:#E6E6E6\ntooltip_fg_color:#574F4A"
 
 # Set GTK settings
 gtk-auto-mnemonics              = 1

--- a/src/gtk-2.0/gtkrc-light.in
+++ b/src/gtk-2.0/gtkrc-light.in
@@ -21,6 +21,8 @@ gtk-color-scheme = "selected_fg_color:#FFFFFF\nselected_bg_color:#48b9c7"
 gtk-color-scheme = "titlebar_fg_color:#212121\ntitlebar_bg_color:#ebe9e8"
 # Links
 gtk-color-scheme = "link_color:#48b9c7\nvisited_link_color:#E040FB"
+# Tooltips
+gtk-color-scheme = "tooltip_bg_color:#574f4a\ntooltip_fg_color:#F5F5F5"
 
 # Set GTK settings
 gtk-auto-mnemonics              = 1

--- a/src/gtk-2.0/gtkrc.in
+++ b/src/gtk-2.0/gtkrc.in
@@ -21,6 +21,8 @@ gtk-color-scheme = "selected_fg_color:#FFFFFF\nselected_bg_color:#48b9c7"
 gtk-color-scheme = "titlebar_fg_color:#FBFBFB\ntitlebar_bg_color:#574f4a"
 # Links
 gtk-color-scheme = "link_color:#48b9c7\nvisited_link_color:#E040FB"
+# Tooltips
+gtk-color-scheme = "tooltip_bg_color:#574f4a\ntooltip_fg_color:#F5F5F5"
 
 # Set GTK settings
 gtk-auto-mnemonics              = 1

--- a/src/gtk-2.0/main.rc
+++ b/src/gtk-2.0/main.rc
@@ -2656,9 +2656,9 @@ style "tooltip" {
   xthickness = 8
   ythickness = 8
 
-  bg[NORMAL]   = @base_color
-  fg[NORMAL]   = @fg_color
-  bg[SELECTED] = @base_color
+  bg[NORMAL]   = @tooltip_bg_color
+  fg[NORMAL]   = @tooltip_fg_color
+  bg[SELECTED] = @tooltip_bg_color
 }
 
 style "disable_text_shadow" {


### PR DESCRIPTION
This inverts the colors for tooltips in the GTK2 Pop Theme. This helps the tooltips stand out against the background.

Fixes #155 