### PR TITLE
Fixes #154

### DIFF
--- a/src/gtk-3.0/3.22/sass/apps/_gnome.scss
+++ b/src/gtk-3.0/3.22/sass/apps/_gnome.scss
@@ -57,6 +57,11 @@ window.csd > headerbar.titlebar > box.linked > button.image-button {
   border-image: none;
 }
 
+// Need to make the entry slightly wider to fit the text. Dunno why it cuts off
+window.csd > headerbar.titlebar > box.linked.horizontal > entry:nth-child(2) {
+  min-width: 6em;
+}
+
 /**********
  * Evince *
  **********/

--- a/src/gtk-3.0/3.22/sass/widgets/_entry.scss
+++ b/src/gtk-3.0/3.22/sass/widgets/_entry.scss
@@ -344,7 +344,7 @@ combobox {
 // This isn't an actual combobox, but it looks like one, so we should theme it
 // the same way.
 
-box.horizontal.linked > entry + button:not(.combo) {
+box.horizontal.linked > entry + button:not(.combo):not(.image-button) {
   @include entry(normal)
 
   &:disabled { @include entry(disabled)}


### PR DESCRIPTION
Applies a :not selector on certain linked buttons to prevent them being styled like entries that preceed them. Also sets a minimum width on the zoom value entry in Eye Of GNOME.

The text in the entry getting cut off is probably a bug (either in eog or in GTK), but nevertheless this fixes it by setting a larger minimum size on _that_ entry.

It also fixes the selector that was causing weirdness with the plus button, so this pretty completely fixes #154 