### PR TITLE
Update cover image URL (cosmic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="https://github.com/system76/pop-gtk-theme/raw/master/Pop_gtk-logo.png"/>
+<img src="https://github.com/system76/pop-gtk-theme/raw/master_cosmic/Pop_gtk-logo.png"/>
 </p>
 
 -------------------


### PR DESCRIPTION
The cover logo currently links to the wrong image URL. There is no explicit 'master' branch. 