### PR TITLE
Bugfixes for v4

### DIFF
--- a/src/gtk3/common/scss/apps/_firefox.scss
+++ b/src/gtk3/common/scss/apps/_firefox.scss
@@ -23,22 +23,7 @@ text:selected {
   button > button {
     border: 1px solid $firefox_border_color;
     border-radius: $corner_radius;
-    //background-color: $light_ui_300;
-    //color: $obverse_fg_color;
     box-shadow: none;
-    
-    //> label {
-    //  color: $fg_color;
-    //}
-    
-    //window > & {
-    //  background-color: $bg_color;
-    //  color: $fg_color;
-    //  
-    //  > label {
-    //    color: $fg_color;
-    //  }
-    //}
   }
 
   entry {
@@ -52,23 +37,24 @@ text:selected {
   button,
   button > button {
     padding: 4px 8px;
+    background-color: $bg_color;
     background-size: auto;
-
-    &:hover { 
-      //background-image: $light_ui_700;
-      background-color: $dark_fg_color;
+    color: $fg_color;
+    
+    &:hover {
+      background-color: $dark_bg_color;
     }
-
+    
     &:active {
-      //background-image: $light_ui_700;
-      background-color: $dark_fg_color;
+      background-color: $darker_bg_color;
     }
     
     &.close {
-      margin: $small_padding 0;
+      margin: $small_padding 0 $small_padding $standard_padding;
       padding: 4px;
       border-radius: $circular_radius;
       background-color: $close_button_color;
+      color: $inverse_fg_color;
       
       &:backdrop {
         background-color: to200($titlebar_fg_color);

--- a/src/gtk3/common/scss/apps/_firefox.scss
+++ b/src/gtk3/common/scss/apps/_firefox.scss
@@ -44,7 +44,7 @@ text:selected {
     &:hover {
       background-color: $dark_bg_color;
     }
-    
+
     &:active {
       background-color: $darker_bg_color;
     }

--- a/src/gtk3/common/scss/apps/_pop-installer.scss
+++ b/src/gtk3/common/scss/apps/_pop-installer.scss
@@ -37,6 +37,15 @@
       border-image: none;
       border-left-width: 12px;
     }
+    
+    &.image-button {
+      // Need to unset these for .image-button classes or the terminal button is
+      // weird.
+      @include flat_button;
+      padding: $tiny_padding_em $small_padding_em;
+      border-width: 0;
+      outline-offset: -6px;
+    }
   }
 
   button.suggested-action {


### PR DESCRIPTION
Re-styles .flat.toggle.image-button widgets in the installer so the normal flat_button style. Fixes #214 , an issue where the Installer mode button styling is being applied incorrectly to the terminal toggle button.

Corrects a theming error heldover from the attempt to fix Firefox dark-mode theming. Fixes #215 , an issue where hover-states in Mozilla apps were using dark colors for the background of :hover and :active buttons.