### PR TITLE
Fixes based on Theme Feedback

### DIFF
--- a/src/gtk3/common/scss/apps/_apps.scss
+++ b/src/gtk3/common/scss/apps/_apps.scss
@@ -19,3 +19,4 @@
 @import 'pop-shop';
 @import 'gnome-control-center';
 @import 'pop-installer';
+@import 'gnome-calendar';

--- a/src/gtk3/common/scss/apps/_gnome-calendar.scss
+++ b/src/gtk3/common/scss/apps/_gnome-calendar.scss
@@ -1,0 +1,11 @@
+// This file is part of the Pop!_GTK Theme.
+// See gtk.scss for full license and copyright information
+/* 
+ * _gnome-calendar.scss - App Overrides for GNOME Calendar
+ *
+ * File credits: Ian Santopietro <isantop@gmail.com>
+ */
+
+datechooser .circular.back-button {
+  background-image: none;
+}

--- a/src/gtk3/common/scss/apps/_nautilus.scss
+++ b/src/gtk3/common/scss/apps/_nautilus.scss
@@ -6,54 +6,50 @@
  * File credits: Ian Santopietro <isantop@gmail.com>
  */
 
-.nautilus-window,
-.nautilus-window notebook,
-.nautilus-window notebook > stack {
-  background-color: $bg_color;
-}
-
-.nautilus-window .floating-bar {
-  min-height: $large_size;
-  padding: 0;
-  transition: $standard_transition, border-width 0;
-  border-width: $border_size;
-  border-style: solid solid none;
-  border-radius: $corner_radius $corner_radius 0 0;
-  border-color: to400($fg_color);
-  background-clip: padding-box;
-  background-color: $dark_bg_color;
-
-  &.bottom.left { // axes left border and border radius
-    margin-right: 8px - 1px;
-    border-left-style: none;
-    border-top-left-radius: 0;
-  }
-
-  &.bottom.right { // axes right border and border radius
-    margin-left: 8px - 1px;
-    border-right-style: none;
-    border-top-right-radius: 0;
-  }
-
-  button {
-    margin: $tiny_padding;
-  }
-}
-
-widget.view .icon-item-background,
-.nautilus-canvas-item {
-  background-color: $color_theme_1;
-  color: $fg_color;
-  text-shadow: $shadow_0;
-}
-
-.nautilus-canvas-item {
-  border-radius: $corner_radius;
-}
-
-// Icon view
 .nautilus-window {
 
+  // New Path Bar in 3.30
+  .path-bar-box > widget.path-bar > box {
+    > button {
+      background-image: none;
+      padding: $tiny_padding_em $small_padding_em;
+      
+      &:checked {
+        border-image: none;
+      }
+    }
+    
+    &:last-child {
+      border-image: radial-gradient(
+        circle closest-corner at center calc(100% - 1px),
+        $color_theme_2 100%,
+        transparent 0%)
+        0 0 2 / 0 0 2px; // sass-lint:disable-line indentation 
+    }
+  }
+  
+  // Zoom controls
+  > popover > stack > box.vertical > box.linked.horizontal 
+  + box.vertical > box.vertical > box.horizontal.linked {
+    margin: $tiny_padding;
+    border-radius: $corner_radius;
+    background-color: $bg_hl_color;
+    box-shadow: $shadow_0;
+    
+    button:disabled {
+      border: none;
+      box-shadow: none;
+    }
+  }
+  
+  // Tiny fix for border radius on popover buttons
+  popover stack box.linked button,
+  popover stack box.linked button:first-child,
+  popover stack box.linked button:last-child {
+    border-radius: $corner_radius;
+  }
+  
+  // Icon View
   widget.view > .icon-item-background {
     padding: 4px;
     border-radius: $corner_radius;
@@ -66,25 +62,49 @@ widget.view .icon-item-background,
       background-color: $color_theme_1;
     }
   }
-}
-
-// Tiny fix for border radius on popover buttons
-popover stack box.linked button,
-popover stack box.linked button:first-child,
-popover stack box.linked button:last-child {
-  border-radius: $corner_radius;
-}
-
-// Zoom controls
-.nautilus-window > popover > stack > box.vertical > box.linked.horizontal 
-+ box.vertical > box.vertical > box.horizontal.linked {
-  margin: $tiny_padding;
-  border-radius: $corner_radius;
-  background-color: $bg_hl_color;
-  box-shadow: $shadow_0;
   
-  button:disabled {
-    border: none;
-    box-shadow: none;
+  widget.view .icon-item-background,
+  .nautilus-canvas-item {
+    background-color: $color_theme_1;
+    color: $fg_color;
+    text-shadow: $shadow_0;
+  }
+
+  .nautilus-canvas-item {
+    border-radius: $corner_radius;
+  }
+  
+  // Floating Bar
+  .floating-bar {
+    min-height: $large_size;
+    padding: 0;
+    transition: $standard_transition, border-width 0;
+    border-width: $border_size;
+    border-style: solid solid none;
+    border-radius: $corner_radius $corner_radius 0 0;
+    border-color: to400($fg_color);
+    background-clip: padding-box;
+    background-color: $dark_bg_color;
+
+    &.bottom.left { // axes left border and border radius
+      margin-right: 8px - 1px;
+      border-left-style: none;
+      border-top-left-radius: 0;
+    }
+
+    &.bottom.right { // axes right border and border radius
+      margin-left: 8px - 1px;
+      border-right-style: none;
+      border-top-right-radius: 0;
+    }
+
+    button {
+      margin: $tiny_padding;
+    }
+  }
+  
+  notebook,
+  notebook > stack {
+    background-color: $bg_color;
   }
 }

--- a/src/gtk3/common/scss/apps/_nautilus.scss
+++ b/src/gtk3/common/scss/apps/_nautilus.scss
@@ -12,14 +12,23 @@
   .path-bar-box > widget.path-bar > box {
     > button {
       padding: $tiny_padding_em $small_padding_em;
+      background-color: transparent;
       background-image: none;
       
       &:checked {
         border-image: none;
       }
+      
+      &:hover {
+        background-color: to100($titlebar_fg_color);
+      }
+      
+      &:active {
+        background-color: to200($titlebar_fg_color);
+      }
     }
     
-    &:last-child {
+    &:last-child > button {
       border-image: radial-gradient(
         circle closest-corner at center calc(100% - 1px),
         $color_theme_2 100%,

--- a/src/gtk3/common/scss/apps/_nautilus.scss
+++ b/src/gtk3/common/scss/apps/_nautilus.scss
@@ -11,8 +11,8 @@
   // New Path Bar in 3.30
   .path-bar-box > widget.path-bar > box {
     > button {
-      background-image: none;
       padding: $tiny_padding_em $small_padding_em;
+      background-image: none;
       
       &:checked {
         border-image: none;

--- a/src/gtk3/common/scss/apps/_pop-installer.scss
+++ b/src/gtk3/common/scss/apps/_pop-installer.scss
@@ -33,9 +33,9 @@
     
     &:checked {
       padding-right: 0;
-      border: 0 solid #faa41a;
-      border-image: none;
+      border: 0 solid $color_theme_2;
       border-left-width: 12px;
+      border-image: none;
     }
     
     &.image-button {


### PR DESCRIPTION
Makes a couple of theme changes and fixes based on feedback received:

1. Fixes a bug in GNOME Calendar that caused two arrows to appear on left-buttons in the date picker widget.

2. Removes pathbar separators in Nautilus on 3.30, since they use them natively upstream.

3. Cleans up the styling for Nautilus to make future maintenance simpler.