### PR TITLE
Fix GNOME weather dark forecast

### DIFF
--- a/src/gtk3/common/scss/apps/_gnome-weather.scss
+++ b/src/gtk3/common/scss/apps/_gnome-weather.scss
@@ -33,3 +33,7 @@ stackswitcher.horizontal.linked.stack-switcher.osd {
     }
   }
 }
+
+window.csd > grid.vertical > stack grid.horizontal > grid.horizontal > grid.horizontal > stack > scrolledwindow > viewport {
+  background-color: transparent;
+}


### PR DESCRIPTION
Fixes the dark Forecast background issue in GNOME Weather.

Fixes #219 