### PR TITLE
Use equivalent borders in terminal

### DIFF
--- a/src/gtk3/common/scss/apps/_gnome-terminal.scss
+++ b/src/gtk3/common/scss/apps/_gnome-terminal.scss
@@ -13,8 +13,7 @@ terminal-window > headerbar.titlebar > box.right > .close {
 
 // Terminal needs a border to help with the case of overlapping windows.
 terminal-window > box {
-  border: 0 solid $titlebar_hl_color;
-  border-width: 0 $border_size $border_size;
+  border: $border_size solid $titlebar_hl_color;
   
   &:backdrop {
     border: $border_size solid lighten($titlebar_bg_color, 5%);


### PR DESCRIPTION
We need to use equivalently size borders between states in terminal. Otherwise
we end up with the terminal window contents "jumping" up and down when the
window is :backdrop'd or not.

Fixes #217