### PR TITLE
Add a text-shadow to Nautilus Desktop items

### DIFF
--- a/src/gtk3/common/scss/_colors.scss
+++ b/src/gtk3/common/scss/_colors.scss
@@ -86,6 +86,9 @@ $titlebar_dl_color: mix($titlebar_bg_color, black, 80%);
 $titlebar_active_color: if($titlebar=='dark', $light_ui_100, $warm_grey_900);
 $close_button_color: mix($red_500, $color_theme_2, 50%);
 
+// Misc Colors
+$text_shadow_color: rgba($black, 0.7);
+
 /*
  * Debug Block
  */

--- a/src/gtk3/common/scss/apps/_nautilus.scss
+++ b/src/gtk3/common/scss/apps/_nautilus.scss
@@ -123,5 +123,8 @@
 .nautilus-desktop.nautilus-canvas-item:not(:selected),
 .caja-desktop.caja-canvas-item:not(:selected) {
   color: $white;
-  text-shadow: $shadow_1;
+  text-shadow: -1px 0 $text_shadow_color,
+    0 1px $text_shadow_color, // sass-lint:disable-line indentation
+    1px 0 $text_shadow_color, // sass-lint:disable-line indentation
+    0 -1px $text_shadow_color; // sass-lint:disable-line indentation
 }

--- a/src/gtk3/common/scss/apps/_nautilus.scss
+++ b/src/gtk3/common/scss/apps/_nautilus.scss
@@ -117,3 +117,11 @@
     background-color: $bg_color;
   }
 }
+
+// Nautilus Desktop Widget
+
+.nautilus-desktop.nautilus-canvas-item:not(:selected),
+.caja-desktop.caja-canvas-item:not(:selected) {
+  color: $white;
+  text-shadow: $shadow_1;
+}


### PR DESCRIPTION
Adds a text shadow to the Nautilus Desktop text, and makes it white by default.