### PR TITLE
Removed ALPHA warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@
 
 A GTK+ theme for Pop!_OS 
 
-*NOTE* This version of the theme is currently in _ALPHA_. It is not considered
-complete or ready for day-to-day use. Certain elements may not be themed 
-correctly.
-
 
 ## Screenshots
 -------------------


### PR DESCRIPTION
Since this is in production now, I've removed the ALPHA warning: `NOTE This version of the theme is currently in ALPHA. It is not considered complete or ready for day-to-day use. Certain elements may not be themed correctly.`