### PR TITLE
Minor tweaks to color palette

### DIFF
--- a/src/gtk3/common/scss/_color-palette.scss
+++ b/src/gtk3/common/scss/_color-palette.scss
@@ -1,5 +1,4 @@
-// This file is part of the Pop!_GTK Theme.
-// See gtk.scss for full license and copyright information
+
 /* 
  * _color-palette.scss - Defines the master color palette
  *
@@ -7,7 +6,7 @@
  */
 
 // Orange
-$orange_100: #FFF066;
+$orange_100: #FFDB91;
 $orange_300: #FFCA40;
 $orange_500: #FAA41A;
 $orange_700: #DE8800;
@@ -15,7 +14,7 @@ $orange_900: #C26C00;
 
 
 // Red
-$red_100: #FF9459;
+$red_100: #FF9262;
 $red_300: #FF793E;
 $red_500: #F15D22;
 $red_700: #CF3B00;
@@ -48,7 +47,7 @@ $blue_900: #00616F;
 
 // Purple
 $purple_100: #D25DE6;
-$purple_300: #B742CB;
+$purple_300: #B84ACB;
 $purple_500: #9C27B0;
 $purple_700: #830E97;
 $purple_900: #6A007E;


### PR DESCRIPTION
Makes the colors more distinct. Especially with Red, Orange, and Yellow, the _100 versions of all three of these look nearly identical. 

This PR separates them out a bit to make them all more distinct as well as to ensure they better match the standard shade (_500) versions.