### PR TITLE
Add a non-transparent border to firefox frames.

### DIFF
--- a/src/gtk3/common/scss/_variables.scss
+++ b/src/gtk3/common/scss/_variables.scss
@@ -25,6 +25,7 @@ $switch_size: 20px;
 $toolbar_size: if($slim == 'false', 42px, 32px);
 $arrow_size: 19px;
 $scrollbar_size: 10px;
+$icon_size: 16px;
 
 // Padding
 $no_padding: 1px;

--- a/src/gtk3/common/scss/apps/_firefox.scss
+++ b/src/gtk3/common/scss/apps/_firefox.scss
@@ -10,7 +10,7 @@
  * track down/fix.
  */
 
-$firefox_border_color: to200($black);
+$firefox_border_color: mix($black, $white, 20%);
 
 // Firefox now uses this for selected items
 text:selected { 
@@ -18,6 +18,10 @@ text:selected {
 }
 
 #MozillaGtkWidget { 
+  headerbar.titlebar {
+    margin: 0;
+    padding: (28px - $icon_size * 1.5) / 2;
+  }
   entry,
   button,
   button > button {
@@ -98,6 +102,11 @@ text:selected {
   > frame > border { 
     border-color: $firefox_border_color;
   }  
+
+  frame {
+    border-color: $bg_color;
+  }
+  
   check,
   radio {
     background-color: transparent;


### PR DESCRIPTION
Fixes #255