### PR TITLE
4.1.1

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -21,7 +21,7 @@ it is very likely an upstream issue.
 
 
 
-**Pop version (run ```head -n 3 /usr/share/themes/Pop/gtk-3.22/gtk.css```):**
+**Pop version (run ```apt policy pop-gtk-theme```):**
 
 
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-gtk-theme (4.1.1) cosmic; urgency=medium
+
+  * Ensure Destructive dialog buttons are always readable. (#267)
+
+ -- Ian Santopietro <isantop@gmail.com>  Tue, 29 Jan 2019 13:50:48 -0700
+
 pop-gtk-theme (4.1.0) cosmic; urgency=medium
 
   * Tweaks to the color Palette to ensure that colors are always distinct.

--- a/src/gtk3/3.22/gtk.scss
+++ b/src/gtk3/3.22/gtk.scss
@@ -1,5 +1,5 @@
 /*
- * Pop!_OS gtk-widgets Theme (The Pop!_GTK Theme) Version 4.0.0
+ * Pop!_OS gtk-widgets Theme (The Pop!_GTK Theme) Version 4.1.1
  * Copyright 2017-2018 System76, Inc.
  *
  * The Pop!_GTK Theme is free software; you can redistribute it and/or

--- a/src/gtk3/common/scss/_colors.scss
+++ b/src/gtk3/common/scss/_colors.scss
@@ -70,7 +70,7 @@ $warning_color: $yellow_500;
 $error_color: $red_700;
 $question_color: $indigo_300;
 $success_color: $green_700;
-$link_color: $dark_color_2;
+$link_color: if($color=="dark", $color_theme_2, $dark_color_2);
 
 $dark_warning_color: if($color=='dark', $yellow_500, $yellow_700);
 

--- a/src/gtk3/common/scss/apps/_nautilus.scss
+++ b/src/gtk3/common/scss/apps/_nautilus.scss
@@ -127,13 +127,7 @@
 // We hate wildcard selectors, but this seems to get rid of the white line. See
 // github.com/pop-os/gtk-theme/issues/266
 .nautilus-desktop-window grid paned overlay notebook box * {
-  border: none;
-  outline-color: transparent;
-  background-clip: border-box;
   background-color: transparent;
-  color: transparent;
-  text-decoration-color: transparent;
-  
 }
 
 .nautilus-desktop.nautilus-canvas-item:not(:selected),

--- a/src/gtk3/common/scss/apps/_nautilus.scss
+++ b/src/gtk3/common/scss/apps/_nautilus.scss
@@ -124,6 +124,18 @@
 
 // Nautilus Desktop Widget
 
+// We hate wildcard selectors, but this seems to get rid of the white line. See
+// github.com/pop-os/gtk-theme/issues/266
+.nautilus-desktop-window grid paned overlay notebook box * {
+  border: none;
+  outline-color: transparent;
+  background-clip: border-box;
+  background-color: transparent;
+  color: transparent;
+  text-decoration-color: transparent;
+  
+}
+
 .nautilus-desktop.nautilus-canvas-item:not(:selected),
 .caja-desktop.caja-canvas-item:not(:selected) {
   color: $white;

--- a/src/gtk3/common/scss/gtk-widgets/_base.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_base.scss
@@ -219,8 +219,9 @@
   }
 }
 
-.link {
-  color: $color_theme_2;
+.link,
+:link {
+  color: $link_color;
 }
 .visited {
   color: darken($color_theme_2, 20%);

--- a/src/gtk3/common/scss/gtk-widgets/_dialog.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_dialog.scss
@@ -61,8 +61,37 @@ messagedialog {
           }
         }
 
+        &:focus {
+          outline-color: rgba($fg_color, 0.2);
+        }
+
         label {
           color: $destructive_color;
+
+          &:hover,
+          &:focus {
+            color: $inverse_fg_color;
+          }
+        }
+      }
+
+      &.suggested-action {
+        background-color: transparent;
+
+        &:hover {
+          background-color: rgba($suggested_color, 0.1);
+
+          &:active {
+            background-color: rgba($suggested_color, 0.2);
+          }
+        }
+
+        &:focus {
+          outline-color: rgba($fg_color, 0.2);
+        }
+
+        label {
+          color: $suggested_color;
 
           &:hover,
           &:focus {

--- a/src/gtk3/common/scss/gtk-widgets/_dialog.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_dialog.scss
@@ -50,8 +50,25 @@ messagedialog {
       color: to800($fg_color);
       box-shadow: none;
       
-      &.destructive-action label {
-        color: $destructive_color;
+      &.destructive-action {
+        background-color: transparent;
+
+        &:hover {
+          background-color: rgba($destructive_color, 0.1);
+
+          &:active {
+            background-color: rgba($destructive_color, 0.2);
+          }
+        }
+
+        label {
+          color: $destructive_color;
+
+          &:hover,
+          &:focus {
+            color: $inverse_fg_color;
+          }
+        }
       }
       
       &:focus {

--- a/src/gtk3/common/scss/gtk-widgets/_infobar.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_infobar.scss
@@ -10,7 +10,6 @@ infobar {
   border: none;
   background-color: $bg_color;
   box-shadow: $shadow_2;
-
   
   &.frame {
     border-radius: $corner_radius;
@@ -19,6 +18,7 @@ infobar {
   label,
   image {
     color: $fg_color;
+    -gtk-icon-style: symbolic;
   }
   
   &.error {
@@ -31,6 +31,20 @@ infobar {
     
     button {
       background-color: mix($bg_color, $error_color, 20%);
+    }
+
+    menu,
+    popover {
+      image,
+      label {
+        color: $fg_color;
+      }
+    }
+    
+    button,
+    button label,
+    button image {
+      color: $inverse_fg_color;
     }
   }
   
@@ -45,6 +59,20 @@ infobar {
     button {
       background-color: mix($bg_color, $question_color, 20%);
     }
+
+    menu,
+    popover {
+      image,
+      label {
+        color: $fg_color;
+      }
+    }
+    
+    button,
+    button label,
+    button image {
+      color: $inverse_fg_color;
+    }
   }
   
   &.warning {
@@ -57,6 +85,7 @@ infobar {
     
     button {
       background-color: mix($bg_color, $warning_color, 20%);
+      color: $obverse_fg_color;
     }
   }
   
@@ -70,6 +99,38 @@ infobar {
     
     button {
       background-color: mix($bg_color, $information_color, 20%);
+      color: $inverse_fg_color;
+    }
+
+    menu,
+    popover {
+      image,
+      label {
+        color: $fg_color;
+      }
+    }
+    
+    button,
+    button label,
+    button image {
+      color: $inverse_fg_color;
+    }
+  }
+  
+  .linked {
+    background-color: rgba($obverse_bg_color, 0.1);
+
+    button {
+      background-color: transparent;
+
+      &:hover {
+        background-color: rgba($inverse_bg_color, 0.1);
+      }
+
+      &:active {
+        background-color: rgba($inverse_bg_color, 0.3);
+      }
     }
   }
 }
+


### PR DESCRIPTION
Ensure destructive dialog buttons are always readable.
Fixes #177 and Fixes #267 

Improve the look and readability of widgets in infobars.
Fixes #232 

Ensure that all types of links are styled.
Fixes #240

Unstyle many nautlius-desktop selectors. 
Fixes #266 