### PR TITLE
Circular button size

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-gtk-theme (4.1.3) cosmic; urgency=medium
+
+  * Make round buttons take up less space.
+
+ -- Ian Santopietro <isantop@gmail.com>  Mon, 11 Feb 2019 13:32:04 -0700
+
 pop-gtk-theme (4.1.2) cosmic; urgency=medium
 
   * Nautilus Desktop menu is no longer transparent. (#272)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-gtk-theme (4.1.2) cosmic; urgency=medium
+
+  * Make round buttons take up less space.
+
+ -- Ian Santopietro <isantop@gmail.com>  Thu, 07 Feb 2019 15:26:51 -0700
+
 pop-gtk-theme (4.1.1) cosmic; urgency=medium
 
   * Ensure Destructive dialog buttons are always readable. (#267)

--- a/src/gtk3/common/scss/gtk-widgets/_button.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_button.scss
@@ -41,6 +41,8 @@
 button,
 .button {
   @extend %button-fallback;
+  min-width: $tiny_size;
+  min-height: $tiny_size;
   padding: $tiny_padding_em $small_padding_em;
   transition: $standard_transition;
   border: none;
@@ -105,10 +107,9 @@ button,
   
   &.round,
   &.circular {
-    min-width: $medium_size;
-    min-height: $medium_size;
-    margin: $mini_padding;
-    padding: $tiny_padding_em;
+    min-width: $large_size;
+    min-height: $large_size;
+    padding: 0;
     border-radius: $circular_radius;
     -gtk-outline-radius: $circular_radius;
   }


### PR DESCRIPTION
Reworks some of the sizing on rounded `.circular` buttons. This helps ensure they're more consistently circular, but more importantly it makes them substantially smaller, which looks much better in most cases and is more consistent with other themes.

Prior:
![screenshot from 2019-02-07 15-15-19](https://user-images.githubusercontent.com/5883565/52447096-0752e680-2aed-11e9-99cf-56d58b4905ae.png)

After:
![screenshot from 2019-02-07 15-15-46](https://user-images.githubusercontent.com/5883565/52447104-0de15e00-2aed-11e9-9d72-fddef497cfe7.png)
