### PR TITLE
Bugfix #272 transparent desktop menu

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-gtk-theme (4.1.2) cosmic; urgency=medium
+
+  * Nautilus Desktop menu is no longer transparent. (#272)
+
+ -- Ian Santopietro <isantop@gmail.com>  Mon, 11 Feb 2019 10:35:05 -0700
+
 pop-gtk-theme (4.1.1) cosmic; urgency=medium
 
   * Ensure Destructive dialog buttons are always readable. (#267)

--- a/src/gtk3/common/scss/apps/_nautilus.scss
+++ b/src/gtk3/common/scss/apps/_nautilus.scss
@@ -126,8 +126,35 @@
 
 // We hate wildcard selectors, but this seems to get rid of the white line. See
 // github.com/pop-os/gtk-theme/issues/266
-.nautilus-desktop-window grid paned overlay notebook box * {
-  background-color: transparent;
+.nautilus-desktop-window {
+  grid paned overlay notebook box * {
+    background-color: transparent;
+  }
+
+  menu,
+  window.popup {
+    background-color: $bg_color;
+
+    :active,
+    :hover {
+      background-color: $darker_bg_color;
+
+      check,
+      radio {
+        @extend %checkradio;
+
+        &:checked,
+        &:indeterminate {
+          background-color: $color_theme_2;
+        }
+      }
+    }
+
+    check,
+    radio {
+      @extend %checkradio;
+    }
+  }
 }
 
 .nautilus-desktop.nautilus-canvas-item:not(:selected),

--- a/src/gtk3/common/scss/gtk-widgets/_menus.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_menus.scss
@@ -6,6 +6,7 @@
  * File credits: Ian Santopietro <isantop@gmail.com>
  */
 
+%menu,
 menu,
 window.popup {
   padding: $mini_padding;


### PR DESCRIPTION
Make nautilus desktop menu non-transparent.

Fixes #272 