### PR TITLE
Set Switch color to transparent.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-gtk-theme (4.1.4) disco; urgency=medium
+
+  * Set switch color to transparent (#270)
+
+ -- Ian Santopietro <isantop@gmail.com>  Wed, 13 Feb 2019 10:02:30 -0700
+
 pop-gtk-theme (4.1.3) cosmic; urgency=medium
 
   * Make round buttons take up less space.

--- a/src/gtk3/common/scss/gtk-widgets/_switch.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_switch.scss
@@ -15,6 +15,7 @@ switch {
   background-repeat: no-repeat;
   background-position: center;
   background-size: contain;
+  color: transparent;
   font-size: 0;
   box-shadow: 
     0 1px 3px rgba($black, 0.12) inset, // sass-lint:disable-line indentation


### PR DESCRIPTION
In GTK 3.24.5, switches now have a text label showing either
| or O instead of the old "ON" and "OFF". We need to style this out
appropriately since in Pop these are drawn through a background image.
Fixes #270 

This is a preemptive pull request for Disco.