### PR TITLE
Adjust sizing and headerbars for new hdy widgets

### DIFF
--- a/src/gtk3/common/scss/_variables.scss
+++ b/src/gtk3/common/scss/_variables.scss
@@ -36,13 +36,13 @@ $small_padding: if($slim == 'false', 8px, 6px);
 $standard_padding: if($slim == 'false', 12px, 10px);
 $large_padding: if($slim == 'false', 16px, 12px);
 
-$no_padding_em: 0.1em;
-$mini_padding_em: 0.2em;
-$tinier_padding_em: 0.4em;
-$tiny_padding_em: if($slim == 'false', 0.6em, 0.4em);
-$small_padding_em: if($slim == 'false', 0.8em, 0.6em);
-$standard_padding_em: if($slim == 'false', 1.2em, 1em);
-$large_padding_em: if($slim == 'false', 1.6em, 1.2em);
+$no_padding_em: if($slim == 'false', 0.1em, 0);
+$mini_padding_em: if($slim == 'false', 0.15em, 0);
+$tinier_padding_em: if($slim == 'false', 0.3em, 0.2em);
+$tiny_padding_em: if($slim == 'false', 0.5em, 0.3em);
+$small_padding_em: if($slim == 'false', 0.6em, 0.3em);
+$standard_padding_em: if($slim == 'false', 1em, 0.8em);
+$large_padding_em: if($slim == 'false', 1.4em, 1em);
 
 // Border Shadows
 $titlebar_border: 

--- a/src/gtk3/common/scss/apps/_gnome-control-center.scss
+++ b/src/gtk3/common/scss/apps/_gnome-control-center.scss
@@ -6,12 +6,19 @@
  * File credits: Ian Santopietro <isantop@gmail.com>
  */
 
-window.csd > box.horizontal > stack > box.vertical > widget > stack { 
-  overlay > box.vertical > grid.horizontal > stack > button.toggle {
-    @include flat_button;
+window.csd {
+  .titlebar > box > headerbar {
+    min-height: $toolbar_size;
+    padding: $mini_padding_em $standard_padding_em;
   }
   
-  viewport > grid.horizontal box row.activatable button.circular.image-button {
-    @include flat_button;
+  > box.horizontal > stack > box.vertical > widget > stack { 
+    overlay > box.vertical > grid.horizontal > stack > button.toggle {
+      @include flat_button;
+    }
+    
+    viewport > grid.horizontal box row.activatable button.circular.image-button {
+      @include flat_button;
+    }
   }
 }

--- a/src/gtk3/common/scss/gtk-widgets/_header-title-bars.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_header-title-bars.scss
@@ -255,12 +255,18 @@ headerbar,
   }
 }
 
+.titlebar hdyleaflet headerbar,
+hdyleaflet headerbar {
+  min-height: $toolbar_size;
+  padding: $mini_padding_em $standard_padding_em;
+}
+
 window > .titlebar,
 window > headerbar {
   box-shadow: $shadow_1;
 }
 
-menu window.popup decoration, {
+menu window.popup decoration {
   margin: 0;
   border-radius: $corner_radius;
   box-shadow: $shadow_3;


### PR DESCRIPTION
Some applications in Disco now use hdytitlebar widgets, which are designed to split the headerbar for use with phones. The current Pop theme doesn't really support these really well, as evidenced by GNOME Control Center having no space between the edge of the headerbars and the close buttons:

![screenshot from 2019-02-26 10-11-15](https://user-images.githubusercontent.com/5883565/53433393-88e1ba00-39b1-11e9-9ad6-22d703e82ce1.png)

This PR addresses these issues.