### PR TITLE
Set a non-destructive background color on list buttons

### DIFF
--- a/src/gtk3/common/scss/gtk-widgets/_list.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_list.scss
@@ -59,6 +59,10 @@ list,
             background-color: rgba($fg_color, 0.2);
           }
         }
+
+        &:checked {
+          background-color: $color_theme_2;
+        }
       }
       
       &.flat label


### PR DESCRIPTION
We use this to set a non-destructive background color on
checked image button children of list rows. This ensures
that such checked buttons are visible at all times.
Fixes #278