### PR TITLE
Remove shadows on treeview headers

### DIFF
--- a/src/gtk3/common/scss/gtk-widgets/_views.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_views.scss
@@ -15,7 +15,8 @@
   }
 }
 
-treeview {
+treeview,
+.background treeview {
   border-radius: 0;
   background-color: $base_color;
   -GtkTreeView-vertical-separator: $tinier_padding;


### PR DESCRIPTION
Shadows were inadvertently being drawn on treeview header buttons. This PR removes them again.