### PR TITLE
Fix padding of labels in nautilus sidebar in disco

### DIFF
--- a/src/gtk3/common/scss/apps/_nautilus.scss
+++ b/src/gtk3/common/scss/apps/_nautilus.scss
@@ -37,6 +37,11 @@
     }
   }
   
+  // Fix labels in 3.32
+  .sidebar-icon {
+    margin-right: 6px;
+  }
+
   // Zoom controls
   > popover > stack > box.vertical > box.linked.horizontal 
   + box.vertical > box.vertical > box.horizontal.linked {


### PR DESCRIPTION
One possible solution to the issue. I've tested in bionic and disco.

Closes #288