### PR TITLE
Updated the link to the icon set

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pop supports Gtk+ 3.22.x
 
 ### Recommendations
 
-- For GTK, use icons alongside [Pop Icon Theme](https://github.com/system76/pop-icon-theme)
+- For GTK, use icons alongside [Pop Icon Theme](https://github.com/pop-os/icon-theme)
 - For fonts, use:
  > Window Titles: Fira Sans SemiBold 10
 


### PR DESCRIPTION
Browsing the repository I noticed that the link to the icons pointed to a non existing github page. I updated the link so that it point towards the right page.