### PR TITLE
Add styling for Nautilus search dropdown button

### DIFF
--- a/src/gtk3/common/scss/apps/_nautilus.scss
+++ b/src/gtk3/common/scss/apps/_nautilus.scss
@@ -36,6 +36,21 @@
         0 0 2 / 0 0 2px; // sass-lint:disable-line indentation 
     }
   }
+
+  // Search button (with arrow)
+  .path-bar-box ~ box button.popup.toggle {
+    border-radius: $corner_radius;
+    background-color: transparent;
+
+    &:hover {
+      background-color: rgba($white, 0.4);
+    }
+
+    label,
+    image {
+      color: $inverse_fg_color;
+    }
+  }
   
   // Fix labels in 3.32
   .sidebar-icon {


### PR DESCRIPTION
Makes the search details dropdown button look not-terrible.

Fixes #294