### PR TITLE
Remove shadows on :active title/headerbar buttons

### DIFF
--- a/src/gtk3/common/scss/gtk-widgets/_header-title-bars.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_header-title-bars.scss
@@ -34,7 +34,7 @@ titlebar {
 
       &:active {
         background-color: rgba($bg_color, 0.4);
-        box-shadow: $shadow_0;
+        box-shadow: none;
       }
     }
 
@@ -74,7 +74,7 @@ titlebar {
     
     &:active {
       background-color: to200($titlebar_fg_color);
-      box-shadow: $shadow_2;
+      box-shadow: none;
     }
     
     &.close {


### PR DESCRIPTION
This was a nice visual touch, but it breaks things sometimes.

Fixes #280