### PR TITLE
Fix Gitg doesn't use monospace font

### DIFF
--- a/src/gtk3/common/scss/gtk-widgets/_textview.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_textview.scss
@@ -13,9 +13,9 @@ textview text {
 }
 
 textview.monospace {
-    font-family: monospace;
+  font-family: monospace;
 }
 
 textview.monospace .context-menu {
-    font: initial;
+  font: initial;
 }

--- a/src/gtk3/common/scss/gtk-widgets/_textview.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_textview.scss
@@ -11,3 +11,11 @@ textview text {
   background-color: $base_color;
   color: $fg_color;
 }
+
+textview.monospace {
+    font-family: monospace;
+}
+
+textview.monospace .context-menu {
+    font: initial;
+}


### PR DESCRIPTION
Gitg's source view doesn't respect Monospace font setting of the desktop
environment. The fix is based on report from quan and as applied in
ubuntu theme.

https://quan.hoabinh.vn/blog/2017/6/46-fix-gitg-doesn-t-use-monospace-font-in-ubuntu
https://bazaar.launchpad.net/~ubuntu-art-pkg/ubuntu-themes/trunk/revision/559