### PR TITLE
Fix 'rgba' typo

### DIFF
--- a/src/gtk3/common/scss/gtk-widgets/_sidebar.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_sidebar.scss
@@ -21,7 +21,7 @@
     background-color: $color_theme_1;
       
     &:backdrop {
-      background-color: rbga($color_theme_1, 0.6);
+      background-color: rgba($color_theme_1, 0.6);
     }
 
     label,


### PR DESCRIPTION
Fixes the following error message:

> Jun 07 09:42:12 popbook firefox.desktop[1641]: (/usr/lib/firefox/firefox:3197): Gtk-WARNING **: 09:42:12.066: Theme parsing error: gtk.css:4421:24: 'rbga' is not a valid color name
