### PR TITLE
Fix typo for RGB in sidebar

### DIFF
--- a/src/gtk3/common/scss/gtk-widgets/_sidebar.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_sidebar.scss
@@ -21,7 +21,7 @@
     background-color: $color_theme_1;
       
     &:backdrop {
-      background-color: rbga($color_theme_1, 0.6);
+      background-color: rgba($color_theme_1, 0.6);
     }
 
     label,


### PR DESCRIPTION
Typo in function name causes an error