### PR TITLE
Fix the incorrect background color on backdrop labels in active list rows

### DIFF
--- a/src/gtk3/common/scss/gtk-widgets/_list.scss
+++ b/src/gtk3/common/scss/gtk-widgets/_list.scss
@@ -81,7 +81,6 @@ list,
       
       label,
       image {
-        background-color: $color_theme_2;
         color: $inverse_fg_color;
       }
       


### PR DESCRIPTION
Corrects the odd behavior noted in pop-os/icon-theme#44

Fixes #308 