### PR TITLE
Rename source package back to pop-gtk-theme

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,9 @@
-pop-gnome-theme (5.0.0) disco; urgency=medium
+pop-gtk-theme (5.0.0) disco; urgency=medium
 
-  * Rename source package 
+  * This is the result of making sure Pop does not break upstream GNOME apps. It's very
+    Pop-y, but with metrics and features that give it 100% feature parity with Adwaita
+    which helps ensure upstream apps will not break if a user is using this theme. 
+  
 
  -- Ian Santopietro <isantop@gmail.com>  Tue, 17 Sep 2019 16:10:46 -0600
 

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: pop-gnome-theme
+Source: pop-gtk-theme
 Section: misc
 Priority: optional
 Maintainer: Ian Santopietro <ian@system76.com>


### PR DESCRIPTION
This is not ideal from a heuristics perspective, because it's not just
a gtk-theme, but also a theme for GNOME Shell. It also signifies our
intent to be taken seriously within the GNOME ecosystem. However, it
breaks some packaging, so...

@pop-os/quality-assurance I'm going to force-merge this because it doesn't affect the generated theme at all, only the build system.

Unless @jackpot51 has any objections.