### PR TITLE
Use actually neutral (not brown) greys in dark theme

### DIFF
--- a/gtk/src/light/gtk-3.20/_colors.scss
+++ b/gtk/src/light/gtk-3.20/_colors.scss
@@ -3,10 +3,10 @@
 
 @import 'pop_os-colors';
 
-$base_color: if($variant == 'light', #ffffff, #2B2928); 
-$text_color: if($variant == 'light', black, white);
-$bg_color: if($variant == 'light', #F6F6F6, #33302F);
-$fg_color: if($variant == 'light', #2B2928, #E6E6E6);
+$base_color: if($variant == 'light', #ffffff, #272727); 
+$text_color: if($variant == 'light', #272727, #cccccc);
+$bg_color: if($variant == 'light', #F6F6F6, #303030);
+$fg_color: if($variant == 'light', #292929, #cccccc);
 
 $selected_fg_color: #000;
 $selected_bg_color: if($variant=='light', #63B1BC, #94EBEB);
@@ -19,7 +19,7 @@ $link_color: if($variant == 'light', darken($selected_bg_color, 10%), lighten($s
 $link_visited_color: if($variant == 'light', darken($selected_bg_color, 20%), lighten($selected_bg_color, 10%));
 $top_hilight: $borders_edge;
 $dark_fill: mix($borders_color, $bg_color, 50%);
-$headerbar_color: if($variant == 'light', #574F4A, #393634);
+$headerbar_color: if($variant == 'light', #574F4A, #363636);
 $menu_color: if($variant == 'light', $base_color, mix($bg_color, $base_color, 20%));
 $popover_bg_color: $bg_color;
 $popover_hover_color: lighten($bg_color, 5%);

--- a/gtk/src/light/gtk-3.20/_ubuntu-colors.scss
+++ b/gtk/src/light/gtk-3.20/_ubuntu-colors.scss
@@ -25,7 +25,7 @@ $terminal_fg_color: white;
 $terminal_borders_color: darken($terminal_bg_color, 10%);
 
 // Widget Colors
-$headerbar_bg_color: if($variant == 'light', #574F4A, #393634);;
+$headerbar_bg_color: if($variant == 'light', #574F4A, #363636);;
 $menubar_bg_color: $headerbar_bg_color;
 $headerbar_fg_color: $porcelain;
 $headerbar_border_color: lighten($headerbar_bg_color, 8%);


### PR DESCRIPTION
Removes the small amount of saturation from the dark theme greys, and uses truly neutral colors instead.

This will help with color-sensitive work, as well as ensuring good contrast for text and images.