### PR TITLE
Adjustments to font weights on lockscreen clock

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -2112,7 +2112,7 @@ $_screenshield_shadow: 0px 0px 6px rgba(0, 0, 0, 0.726);
 .screen-shield-clock {
   color: white;
   text-shadow: $_screenshield_shadow;
-  font-weight: bold;
+  font-weight: 200;
   text-align: center;
   padding-bottom: 1.5em;
 }
@@ -2125,7 +2125,7 @@ $_screenshield_shadow: 0px 0px 6px rgba(0, 0, 0, 0.726);
 
 .screen-shield-clock-date { 
   font-size: 28pt;
-  font-weight: normal;
+  font-weight: 300;
 }
 
 .screen-shield-notifications-container {


### PR DESCRIPTION
This PR adjusts the weight of the font for the lockscreen clock to better match the appearance of the old theme.

Before:
![locksreen-old](https://user-images.githubusercontent.com/5883565/66143617-bb493a80-e5c4-11e9-9e5c-621da027d3f9.png)

After:
![lockscreen-new](https://user-images.githubusercontent.com/5883565/66143638-c308df00-e5c4-11e9-9aa6-3b17084e9344.png)

Fixes #332 