### PR TITLE
Restore panel corners

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -28,7 +28,7 @@ $cakeisalie: "This stylesheet is generated, DO NOT EDIT";
 
 $modal_radius: 6px;
 $button_radius: 4px;
-$panel-corner-radius: 0;
+$panel-corner-radius: 4px;
 
 $_trough_color: transparentize($fg_color, 0.9);
 $_bubble_borders_color: lighten($borders_color, if($variant=='light', 0%, 5%));
@@ -852,7 +852,7 @@ StScrollBar {
     -panel-corner-border-color: transparent;
 
     &:active, &:overview, &:focus {
-      -panel-corner-border-color: lighten($selected_bg_color,5%);
+      -panel-corner-border-color: $entry_color;
     }
 
     &.lock-screen, &.login-screen, &.unlock-screen {


### PR DESCRIPTION
In the new theme panel corners were getting disabled. This PR restores these and matches the panel corner radius to the window titlebar corner radius.

Before: 
![Screenshot from 2019-10-03 10-03-33](https://user-images.githubusercontent.com/5883565/66143907-327ece80-e5c5-11e9-9820-f68d4a616730.png)

After:
![Screenshot from 2019-10-03 10-03-39](https://user-images.githubusercontent.com/5883565/66143920-39a5dc80-e5c5-11e9-962d-a9eb0d207a37.png)

