### PR TITLE
Genericize Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,48 +3,25 @@
 If this is a bug, please use the template below. If this is a question or general discussion topic, please start a conversation in our chat https://chat.pop-os.org/ or post on our subreddit https://reddit.com/r/pop_os - as those are the proper forums for that type of discussion.
 
 -->
+**Describe the problem:**
+<!-- 
+Please take a screenshot demonstrating the issue and include it below.
+-->
 
-**NOTE: Before reporting a bug, please check whether it also occurs with other themes.**
-> If the bug also occurs with other themes (especially upstream default theme),
-it is very likely an upstream issue.
+**Steps to reproduce:**
+1. 
 
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-**Distribution (run `cat /etc/os-release`):**
-
-
-
-**Gtk+ 3.0 version - (run ```apt policy libgtk-3-0```):**
-
-
-
-**Desktop environment:**
+**Distribution:**
+<!--
+run:
+    cat /etc/os-release | grep -i pretty_name
+-->
 
 
-
-**Pop version (run ```apt policy pop-gtk-theme```):**
-
-
-
-**Related Application and/or Shell theming (or name of widget)**
-
-
-
-**Actual issue**
-
-
-
-**Steps to reproduce**
-
-
-
-**Expected behavior**
-
-
-
-**Behavior in Adwaita**
-
-
-
-**Other Note (feature-request, question, etc...)**
-
-
+**Pop version:**
+<!--
+run: 
+    apt policy pop-gtk-theme | grep -i installed
+    flatpak info org.gtk.Gtk3theme.Pop
+-->
+    


### PR DESCRIPTION
In discussing #353 in-person it was brought up that our current issue template probably discourages people from reporting issues due to an excessive amount of information it requests. This PR removes most of the questions asked by the previous issue template and instead asks only the minimum required to get a useful bug report. This will hopefully provide less of a barrier to reporting the issue, and increases the number of bug reports we get.