### PR TITLE
Increase Nautilus listview header button contrast

### DIFF
--- a/gtk/src/light/gtk-3.20/_apps.scss
+++ b/gtk/src/light/gtk-3.20/_apps.scss
@@ -106,6 +106,7 @@ $small_radius: 4px;
         border: 1px solid $borders_color;
         border-top-width: 0;
         border-left-width: 0;
+        color: rgba($fg_color, 0.7);
 
         &:first-child {
           border-left-width: 0px;


### PR DESCRIPTION
Darkens the Nautilus listview column header color (lightens in the dark theme). This improves the visibility of the header and more clearly indicates it's clickable.

Fixes #326 