### PR TITLE
Incrase the opacity of .dim-label

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -209,7 +209,7 @@ label {
 }
 
 .dim-label {
-  opacity: 0.55;
+  opacity: 0.7;
   text-shadow: none;
 }
 

--- a/gtk/src/light/gtk-3.20/granite/_palette.scss
+++ b/gtk/src/light/gtk-3.20/granite/_palette.scss
@@ -10,75 +10,75 @@
 // be fully compatible. This maps our Pop names to the elementary names.
 
 /* Strawberry */
-@define-color STRAWBERRY_100 #ff8c82;
-@define-color STRAWBERRY_300 #ed5353;
-@define-color STRAWBERRY_500 #c6262e;
-@define-color STRAWBERRY_700 #a10705;
-@define-color STRAWBERRY_900 #7a0000;
+@define-color STRAWBERRY_100 #{"" + "#ff8c82"};
+@define-color STRAWBERRY_300 #{"" + "#ed5353"};
+@define-color STRAWBERRY_500 #{"" + "#c6262e"};
+@define-color STRAWBERRY_700 #{"" + "#a10705"};
+@define-color STRAWBERRY_900 #{"" + "#7a0000"};
 
 /* Orange */
-@define-color ORANGE_100 #ffc27d;
-@define-color ORANGE_300 #ffa154;
-@define-color ORANGE_500 #f37329;
-@define-color ORANGE_700 #cc3b02;
-@define-color ORANGE_900 #a62100;
+@define-color ORANGE_100 #{"" + "#ffc27d"};
+@define-color ORANGE_300 #{"" + "#ffa154"};
+@define-color ORANGE_500 #{"" + "#f37329"};
+@define-color ORANGE_700 #{"" + "#cc3b02"};
+@define-color ORANGE_900 #{"" + "#a62100"};
 
 /* Banana */
-@define-color BANANA_100 #fff394;
-@define-color BANANA_300 #ffe16b;
-@define-color BANANA_500 #f9c440;
-@define-color BANANA_700 #d48e15;
-@define-color BANANA_900 #ad5f00;
+@define-color BANANA_100 #{"" + "#fff394"};
+@define-color BANANA_300 #{"" + "#ffe16b"};
+@define-color BANANA_500 #{"" + "#f9c440"};
+@define-color BANANA_700 #{"" + "#d48e15"};
+@define-color BANANA_900 #{"" + "#ad5f00"};
 
 /* Lime */
-@define-color LIME_100 #d1ff82;
-@define-color LIME_300 #9bdb4d;
-@define-color LIME_500 #68b723;
-@define-color LIME_700 #3a9104;
-@define-color LIME_900 #206b00;
+@define-color LIME_100 #{"" + "#d1ff82"};
+@define-color LIME_300 #{"" + "#9bdb4d"};
+@define-color LIME_500 #{"" + "#68b723"};
+@define-color LIME_700 #{"" + "#3a9104"};
+@define-color LIME_900 #{"" + "#206b00"};
 
 /* Blueberry */
-@define-color BLUEBERRY_100 #8cd5ff;
-@define-color BLUEBERRY_300 #64baff;
-@define-color BLUEBERRY_500 #3689e6;
-@define-color BLUEBERRY_700 #0d52bf;
-@define-color BLUEBERRY_900 #002e99;
+@define-color BLUEBERRY_100 #{"" + "#8cd5ff"};
+@define-color BLUEBERRY_300 #{"" + "#64baff"};
+@define-color BLUEBERRY_500 #{"" + "#3689e6"};
+@define-color BLUEBERRY_700 #{"" + "#0d52bf"};
+@define-color BLUEBERRY_900 #{"" + "#002e99"};
 
 /* Grape */
-@define-color GRAPE_100 #e4c6fa;
-@define-color GRAPE_300 #cd9ef7;
-@define-color GRAPE_500 #a56de2;
-@define-color GRAPE_700 #7239b3;
-@define-color GRAPE_900 #452981;
+@define-color GRAPE_100 #{"" + "#e4c6fa"};
+@define-color GRAPE_300 #{"" + "#cd9ef7"};
+@define-color GRAPE_500 #{"" + "#a56de2"};
+@define-color GRAPE_700 #{"" + "#7239b3"};
+@define-color GRAPE_900 #{"" + "#452981"};
 
 /* Cocoa */
-@define-color COCOA_100 #a3907c;
-@define-color COCOA_300 #8a715e;
-@define-color COCOA_500 #715344;
-@define-color COCOA_700 #57392d;
-@define-color COCOA_900 #3d211b;
+@define-color COCOA_100 #{"" + "#a3907c"};
+@define-color COCOA_300 #{"" + "#8a715e"};
+@define-color COCOA_500 #{"" + "#715344"};
+@define-color COCOA_700 #{"" + "#57392d"};
+@define-color COCOA_900 #{"" + "#3d211b"};
 
 /* Silver */
-@define-color SILVER_100 #fafafa;
-@define-color SILVER_300 #d4d4d4;
-@define-color SILVER_500 #abacae;
-@define-color SILVER_700 #7e8087;
-@define-color SILVER_900 #555761;
+@define-color SILVER_100 #{"" + "#fafafa"};
+@define-color SILVER_300 #{"" + "#d4d4d4"};
+@define-color SILVER_500 #{"" + "#abacae"};
+@define-color SILVER_700 #{"" + "#7e8087"};
+@define-color SILVER_900 #{"" + "#555761"};
 
 /* Slate */
-@define-color SLATE_100 #95a3ab;
-@define-color SLATE_300 #667885;
-@define-color SLATE_500 #485a6c;
-@define-color SLATE_700 #273445;
-@define-color SLATE_900 #0e141f;
+@define-color SLATE_100 #{"" + "#95a3ab"};
+@define-color SLATE_300 #{"" + "#667885"};
+@define-color SLATE_500 #{"" + "#485a6c"};
+@define-color SLATE_700 #{"" + "#273445"};
+@define-color SLATE_900 #{"" + "#0e141f"};
 
 /* Black */
-@define-color BLACK_100 #666;
-@define-color BLACK_300 #4d4d4d;
-@define-color BLACK_500 #333;
-@define-color BLACK_700 #1a1a1a;
-@define-color BLACK_900 #000;
+@define-color BLACK_100 #{"" + "#666"};
+@define-color BLACK_300 #{"" + "#4d4d4d"};
+@define-color BLACK_500 #{"" + "#333"};
+@define-color BLACK_700 #{"" + "#1a1a1a"};
+@define-color BLACK_900 #{"" + "#000"};
  
 /* Basic UI define */
 
-@define-color fg_color #{'' + $fg_color};
+@define-color fg_color #{"" + $fg_color};


### PR DESCRIPTION
Ensures that subtitles of headerbars are legible and high-contrast

After this change: 
![Screenshot from 2019-10-14 10-41-57](https://user-images.githubusercontent.com/5883565/66768460-de4ed680-ee6f-11e9-8b80-75ec1421ba88.png)

Fixes #325 