### PR TITLE
Remove old errant unsupported color functions

### DIFF
--- a/gtk/src/light/gtk-3.20/granite/_nice-scales.scss
+++ b/gtk/src/light/gtk-3.20/granite/_nice-scales.scss
@@ -28,15 +28,15 @@ scale {
   &.warmth trough {
     background-image: linear-gradient(
       to right,
-      to400(#FFD7A1),
-      to600(#FFAD00)
+      rgba(#FFD7A1, 0.4),
+      rgba(#FFAD00, 0.6)
     );
   }
   &.warmth:dir(rtl) trough {
     background-image: linear-gradient(
       to left,
-      to400(#FFD7A1),
-      to600(#FFAD00)
+      rgba(#FFD7A1, 0.4),
+      rgba(#FFAD00, 0.6)
     );
   }
   


### PR DESCRIPTION
Fixes #368

Testing: Ensure that the theme installs, nothing looks majorly broken, and that the error messages in #368 are gone.