### PR TITLE
Revert "Darken borders color"

### DIFF
--- a/gtk/src/light/gtk-3.20/_colors.scss
+++ b/gtk/src/light/gtk-3.20/_colors.scss
@@ -12,7 +12,7 @@ $selected_fg_color: #000;
 $selected_bg_color: if($variant=='light', #63B1BC, #94EBEB);
 
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
-$borders_color: if($variant == 'light', rgba(darken($bg_color, 18%), 0.7), rgba(darken($bg_color, 10%), 0.7));
+$borders_color: if($variant == 'light', rgba(darken($bg_color, 18%), 0.5), rgba(darken($bg_color, 10%), 0.5));
 $alt_borders_color: if($variant == 'light', rgba(darken($bg_color, 24%), 0.5), rgba(darken($bg_color, 18%), 0.5));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
 $link_color: if($variant == 'light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 20%));

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -4438,12 +4438,6 @@ colorchooser .popover.osd { border-radius: 5px; }
 /********
  * Misc *
  ********/
-
-// Drag handles (i.e. in Settings > Search)
-.drag-handle {
-  color: rgba($fg_color, 0.6);
-}
-
 //content view (grid/list)
 .content-view {
   background-color: darken($bg_color,7%);


### PR DESCRIPTION
Reverts pop-os/gtk-theme#371

This is actually a bad way to do this, and we should fix it in the application instead. This has been taken care of in pop-os/gnome-control-center#52 and upstream at https://gitlab.gnome.org/GNOME/gnome-control-center/merge_requests/597