### PR TITLE
Remove Yaru terminal styling

### DIFF
--- a/gtk/src/light/gtk-3.20/_apps.scss
+++ b/gtk/src/light/gtk-3.20/_apps.scss
@@ -148,67 +148,6 @@ $small_radius: 4px;
       text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
     }
   }
-
-  /***********
- * Terminal *
- ***********/
-terminal-window {
-
-    // use unity 8 colors
-    // only colors, let everything else be inherited
-    .terminal-screen {
-        // inherits from .background
-        background-color: $terminal_bg_color;
-        color: $terminal_fg_color;
-
-        &:backdrop {
-            background-color: lighten($terminal_bg_color, 2%);
-            color: $backdrop_selected_fg_color;
-        }
-    }
-
-    notebook {
-        scrollbar {
-            // inherits from scrollbar
-            $_scrollbar_bg: darken($headerbar_bg_color, 5%);
-            $_scrollbar_bc: darken($terminal_borders_color, 5%);
-            background-color: transparent;
-            border-color: transparent;
-
-            &:backdrop {
-                background-color: transparent;
-                border-color: transparent
-            }
-
-            slider {
-                // avoids scrollbar protruding from the terminal window on wayland session
-                // workaround for https://bugs.launchpad.net/ubuntu/+source/gnome-terminal/+bug/1720651
-                margin: 0;
-                border-width: 3px;
-
-                $c: $terminal_fg_color;
-                background-color: gtkalpha(currentColor, 0.3);
-
-                &:hover:active {
-                    background-color: gtkalpha(currentColor, 0.4);
-                }
-
-                &:backdrop {
-                    background-color: gtkalpha(currentColor, 0.7);
-                }
-
-                &:disabled {
-                    background-color: transparent;
-                }
-            }
-
-            &.dragging,
-            &.hovering {
-                background-color: transparent;
-            }
-        }
-    }
-}
   
   /******************
    * GNOME Software *


### PR DESCRIPTION
This caused #369, and doesn't seem to be necessary for the correct
theming to apply. It would be better to remove it.

Fixes #369 