### PR TITLE
Use a less-grey color for disabled headerbar entries

### DIFF
--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -256,6 +256,10 @@ headerbar,
     }
   }
 
+  entry:disabled {
+    color: rgba($fg_color, 0.8);
+  }
+
   separator {
     background: image(darken(#3d3d3d, 11%));
   }


### PR DESCRIPTION
Helps ensure contrast of text in disabled headerbar entries.

Fixes #391 

After this change:
![Screenshot from 2019-10-30 16-31-15](https://user-images.githubusercontent.com/5883565/67904382-d19ad580-fb33-11e9-88b7-161fed0ca78b.png)
