### PR TITLE
Fix for Paned Titlebar separators

### DIFF
--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -470,6 +470,22 @@ headerbar,
   }
 }
 
+// separators in paned headerbars, #405
+// We can't seem to use rgba here, so we darken the 
+// headerbar_bg_color instead.
+paned.titlebar > separator {
+  color: darken($headerbar_bg_color, 5%);
+  background: image(darken($headerbar_bg_color, 5%));
+  background-color: darken($headerbar_bg_color, 5%);
+
+  &:backdrop {
+  color: darken($headerbar_bg_color, 3%);
+  background: image(darken($headerbar_bg_color, 3%));
+  background-color: darken($headerbar_bg_color, 3%);
+  }
+}
+
+
 // titlebutton
 button.titlebutton {
 

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -260,7 +260,9 @@ headerbar,
     color: rgba($fg_color, 0.8);
   }
 
-  separator {
+  // Also include backdrop styling, because they turn white in :backdrop
+  separator,
+  separator:backdrop {
     background: image(rgba($fg_color, if($variant == 'light', 0.2, 0.1)));
   }
 

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -261,9 +261,12 @@ headerbar,
   }
 
   // Also include backdrop styling, because they turn white in :backdrop
-  separator,
-  separator:backdrop {
-    background: image(rgba($fg_color, if($variant == 'light', 0.2, 0.1)));
+  separator {
+    background: image(darken($headerbar_bg_color, 5%));
+
+    &:backdrop {
+      background: image(darken($headerbar_bg_color, 3%));
+    }
   }
 
   @if $variant=='light' {


### PR DESCRIPTION
This is particularly apparent in GNOME Disks, as in #405 . Paned.titlebar widgets don't have styling applied to their separators, causing these to be oddly colored in Pop.

This also applies our regular headerbar > separator styling to the `:backdrop` state, as these are currently losing their styling and turning white on unfocused/:backdrop windows.

Before: 
![Screenshot from 2019-11-11 10-51-39](https://user-images.githubusercontent.com/5883565/68610425-f3218880-0474-11ea-983c-6d03effb5439.png)

After:
![Screenshot from 2019-11-11 11-18-25](https://user-images.githubusercontent.com/5883565/68610444-fe74b400-0474-11ea-8f10-481c96cb2251.png)

Fixes #405 