### PR TITLE
Add backdrop styling to slider scales

### DIFF
--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -889,6 +889,16 @@ scale {
     transition: $button_transition;
     transition-property: background, border, box-shadow;
 
+    &:backdrop {
+      border: 1px solid $selected_bg_color;
+      background-image: none;
+      background-color: mix($selected_bg_color, $bg_color, 60%);
+      border-radius: 100%;
+      box-shadow: 0 1px 0 rgba(black, 0.1);
+      transition: $button_transition;
+      transition-property: background, border, box-shadow;
+    }
+
     &:hover { 
       @include button(hover-alt, $edge: none);
       background-image: none;
@@ -904,9 +914,17 @@ scale {
     &:disabled { 
       @include button(insensitive);
       background-image: none;
-      background-color: rgba($selected_bg_color, 0.6);
+      background-color: rgba($selected_bg_color, 0.5);
       border-color: rgba($selected_bg_color, 0.6);
       box-shadow: none;
+
+      &:backdrop {
+        @include button(insensitive);
+        background-image: none;
+        background-color: rgba($selected_bg_color, 0.3);
+        border-color: rgba($selected_bg_color, 0.5);
+        box-shadow: none;
+      }
     }
 
     // ...on selected list rows


### PR DESCRIPTION
We previously weren't applying any, so they reverted to the
normal button styling in backdrop, which looks weird.

Fixes #408 

Before this PR:

![Screenshot from 2019-11-13 15-14-47](https://user-images.githubusercontent.com/5883565/68809397-15f49e00-0629-11ea-9e4c-5818ad9e99cf.png)![Screenshot from 2019-11-13 15-14-37](https://user-images.githubusercontent.com/5883565/68809403-1ab95200-0629-11ea-9423-d4534c23a782.png)

After:
![Screenshot from 2019-11-13 15-21-15](https://user-images.githubusercontent.com/5883565/68809481-43414c00-0629-11ea-97aa-32fbec6ff85b.png)![Screenshot from 2019-11-13 15-21-07](https://user-images.githubusercontent.com/5883565/68809483-450b0f80-0629-11ea-8d2f-ee2529e71e64.png)
