### PR TITLE
Fixed a bug where the Screen Shield would display the top panel fully.

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -2157,8 +2157,6 @@ $_screenshield_shadow: 0px 0px 6px rgba(0, 0, 0, 0.726);
 
 .screen-shield-notification-count-text { padding: 0px 0px 0px 12px; }
 
-#panel.lock-screen { background-color: transparentize($osd_bg_color, 0.5); }
-
 .screen-shield-background { //just the shadow, really
   background: black;
   box-shadow: 0px 2px 4px transparentize(black,0.6);


### PR DESCRIPTION
The theme code for the panel was already properly applied elsewhere in the code and then a new directive was given under /gnome-shell/src/gnome-shell-sass/_common.scss, which rendered the top panel inappropriately.

Fixes #423