### PR TITLE
fix: Set the GDM background correctly

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
@@ -6,11 +6,11 @@
 }
 
 .login-dialog {
-  $_gdm_bg: $gdm_grey;
   //reset
   border: none;
-  background-color: $_gdm_bg;
-
+  background-color: transparent;
+  
+  $_gdm_bg: $gdm_grey;
 
   StEntry {
     @if $variant=='dark' {

--- a/gnome-shell/src/gnome-shell-sass/widgets/_screen-shield.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_screen-shield.scss
@@ -66,7 +66,7 @@
 }
 
 #lockDialogGroup {
-  background-color: lighten(#2e3436, 8%);
+  background-color: $gdm_grey;
 }
 
 #unlockDialogNotifications {


### PR DESCRIPTION
This prevents blue-grey flashes and should set the background on secondary monitors as well.