### PR TITLE
5.1.2 - Update asset links for gresource theme

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-gtk-theme (5.1.2) focal; urgency=medium
+
+  * Update asset links for gresource theme
+
+ -- Jeremy Soller <jeremy@system76.com>  Mon, 30 Mar 2020 09:33:28 -0600
+
 pop-gtk-theme (5.1.1) focal; urgency=medium
 
   * Support gdm3-theme.gresource alternative

--- a/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
@@ -155,7 +155,7 @@
   .calendar-day-with-events {
     color: lighten($fg_color,10%);
     font-weight: bold;
-    background-image: url("/usr/share/gnome-shell/theme/Pop/calendar-today.svg");
+    background-image: url("resource:///org/gnome/shell/theme/calendar-today.svg");
   }
 
   .calendar-other-month-day {

--- a/gnome-shell/src/gnome-shell-sass/widgets/_check-box.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_check-box.scss
@@ -11,24 +11,24 @@ $check_width: 24px;
     width: $check_width;
     height: $check_height;
     background-image: if($variant == 'light', 
-      url("/usr/share/gnome-shell/theme/Pop/checkbox-off.svg"),
-      url("/usr/share/gnome-shell/theme/Pop/checkbox-off-dark.svg"));
+      url("resource:///org/gnome/shell/theme/checkbox-off.svg"),
+      url("resource:///org/gnome/shell/theme/checkbox-off-dark.svg"));
   }
   &:focus StBin {
     background-image: if($variant == 'light', 
-      url("/usr/share/gnome-shell/theme/Pop/checkbox-off-focused.svg"),
-      url("/usr/share/gnome-shell/theme/Pop/checkbox-off-focused-dark.svg"));
+      url("resource:///org/gnome/shell/theme/checkbox-off-focused.svg"),
+      url("resource:///org/gnome/shell/theme/checkbox-off-focused-dark.svg"));
   }
 
   &:checked StBin {
     background-image: if($variant == 'light', 
-      url("/usr/share/gnome-shell/theme/Pop/checkbox.svg"),
-      url("/usr/share/gnome-shell/theme/Pop/checkbox-dark.svg"));
+      url("resource:///org/gnome/shell/theme/checkbox.svg"),
+      url("resource:///org/gnome/shell/theme/checkbox-dark.svg"));
   }
 
   &:focus:checked StBin {
     background-image: if($variant == 'light', 
-      url("/usr/share/gnome-shell/theme/Pop/checkbox-focused.svg"),
-      url("/usr/share/gnome-shell/theme/Pop/checkbox-focused-dark.svg"));
+      url("resource:///org/gnome/shell/theme/checkbox-focused.svg"),
+      url("resource:///org/gnome/shell/theme/checkbox-focused-dark.svg"));
   }
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
@@ -17,7 +17,7 @@ $dash_border_radius: $modal_radius * 1.5;
   }
 
   .placeholder {
-    // background-image: url("/usr/share/gnome-shell/theme/Pop/dash-placeholder.svg");
+    // background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
     background-image:none;
     background-size: contain;
     height: $dash_placeholder_size;

--- a/gnome-shell/src/gnome-shell-sass/widgets/_switches.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_switches.scss
@@ -9,8 +9,8 @@ $switch_width: 46px;
   height: $switch_height;
   width: $switch_width;
   background-size: contain;
-  background-image: if($variant == 'light', url("/usr/share/gnome-shell/theme/Pop/toggle-off.svg"),url("/usr/share/gnome-shell/theme/Pop/toggle-off-dark.svg"));
+  background-image: if($variant == 'light', url("resource:///org/gnome/shell/theme/toggle-off.svg"),url("resource:///org/gnome/shell/theme/toggle-off-dark.svg"));
   &:checked { 
-    background-image: if($variant == 'light', url("/usr/share/gnome-shell/theme/Pop/toggle-on.svg"),url("/usr/share/gnome-shell/theme/Pop/toggle-on-dark.svg"));
+    background-image: if($variant == 'light', url("resource:///org/gnome/shell/theme/toggle-on.svg"),url("resource:///org/gnome/shell/theme/toggle-on-dark.svg"));
   }
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_workspace-thumbnails.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_workspace-thumbnails.scss
@@ -17,7 +17,7 @@
 
   // drag and drop indicator
   .placeholder {
-    background-image: url("/usr/share/gnome-shell/theme/Pop/dash-placeholder.svg");
+    background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
     background-size: contain;
     height: 24px;
   }


### PR DESCRIPTION
Will rebase and tag when approved. This brings back checkboxes, calendar items, etc. All of the linked assets are part of the gresource file.