### PR TITLE
fix: Use FG color for hovered menu items.

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_popovers.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_popovers.scss
@@ -45,7 +45,7 @@ $popover_arrow_height: 12px;
   }
 
   &.selected {
-    background-color: transparentize(white, if($variant=='light', 0.2, 0.9));
+    background-color: rgba($fg_color, 0.1);
     color: $fg_color;
   }
 


### PR DESCRIPTION
Uses the foreground color in a semi-transparent state to indicate a hovered menu item. This looks better in both light and dark themes, ensuring that items are lightened in the dark theme and darkened in the light theme.