### PR TITLE
fix: Install extra files to ensure themes work

### DIFF
--- a/gnome-shell/src/light/meson.build
+++ b/gnome-shell/src/light/meson.build
@@ -1,0 +1,14 @@
+# This is an hack we need to remove once meson fixes this issue:
+#  https://github.com/mesonbuild/meson/issues/2320
+
+custom_target('style-css',
+  input: style_css,
+  output: output_styles,
+  command: [
+    gnomeshell_copy_and_rename,
+    '--input', '@INPUT@',
+    '--output', '@OUTPUT@',
+  ],
+  install: true,
+  install_dir: install_dir,
+)

--- a/gnome-shell/src/meson.build
+++ b/gnome-shell/src/meson.build
@@ -107,6 +107,10 @@ foreach variant: variants
     subdir(variant)
   endif
 
+  if not is_variant
+    subdir('light')
+  endif
+
   ignore_variants = []
   if not is_variant
     foreach v: variants

--- a/gtk/src/light/gtk-3.20/meson.build
+++ b/gtk/src/light/gtk-3.20/meson.build
@@ -1,7 +1,7 @@
 gnome = import('gnome')
 sassc = find_program('sassc')
 
-gtk3_dir = join_paths(theme_dir, 'gtk-3.20')
+gtk3_dir = join_paths(theme_dir, 'gtk-3.0')
 
 # theme sources .scss files
 gtk3_scss_sources = [


### PR DESCRIPTION
This ensures that all of the necessary files are installed into the correct directories for the theme. 

This ensures that the theme can be selected and installed on any OS, and makes overriding certain things easier/possible in Pop_OS. These are standards-compliant ways to do the theme.

Fixes #447 