### PR TITLE
fix: Match search result section stying to search results themselves.

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_search-results.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_search-results.scss
@@ -75,7 +75,7 @@
     .list-search-provider-details {
       width: 120px;
       margin-top: 0;
-      color: rgba($osd_fg_color, 0.7);
+      // color: rgba($osd_fg_color, 0.7);
       // font-weight: bold;
     }
   }


### PR DESCRIPTION
As requested, this PR matches the styling of search results section headers to the styling of the search results themselves.