### PR TITLE
fix(shell): Use correct BG color for panel

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
@@ -2,7 +2,6 @@
 // a.k.a. the panel
 
 $panel_corner_radius: $base_border_radius+1;
-$panel_bg_color: #000;
 $panel_fg_color: #ccc;
 $panel_height: 1.86em;
 


### PR DESCRIPTION
Updates the top-panel color to use the correct value (`darken(#2B2928, 3%)`, or #232121) instead of pure black. This was likely a bug introduced with the updates for 20.04, and was missed in the initial release.

For testing this:
1. Ensure that the current BG color is #000, or pure black
2. After applying this change, ensure that the panel is #232121

Fixes #457 