### PR TITLE
fix(gtk): Fix transparent dropdown in GNUCash

### DIFF
--- a/gtk/src/light/gtk-3.0/_tweaks.scss
+++ b/gtk/src/light/gtk-3.0/_tweaks.scss
@@ -610,49 +610,50 @@ radio {
   }
 }
 
-// treeview.view Progressbar improvements
-treeview.view.trough,
-treeview.view.progressbar {
-  background: none;
-  border-bottom: 3px solid transparent;
-  background-color: transparent;
-}
-
-treeview.view.progressbar {
-  background: none;
-  background-color: transparent;
-  border-bottom-color: $selected_bg_color;
-}
-
-treeview.view.progressbar:selected {
-  background: none;
-  background-color: transparent;
-  border-bottom-color: $selected_fg_color;
-}
-
-treeview.view.trough {
-  background: none;
-  background-color: transparent;
-  border-bottom-color: rgba($fg_color, 0.2);
-}
-
-treeview.view.trough:selected {
-  background: none;
-  background-color: transparent;
-  border-bottom-color: rgba($selected_fg_color, 0.2);
-}
-
-treeview.view {
-  background: none;
-  color: $fg_color;
-  background-color: transparent;
-}
-
-treeview.view:selected {
-  background: none;
-  color: $selected_fg_color;
-  background-color: $selected_bg_color;
-}
+/******************************************
+ * treeview.view Progressbar improvements *
+ ******************************************/
+ treeview.view.trough,
+ treeview.view.progressbar {
+   background: none;
+   border-bottom: 3px solid transparent;
+   background-color: transparent;
+ }
+ 
+ treeview.view.progressbar {
+   background: none;
+   background-color: transparent;
+   border-bottom-color: $selected_bg_color;
+ }
+ 
+ treeview.view.progressbar:selected {
+   background: none;
+   background-color: transparent;
+   border-bottom-color: $selected_fg_color;
+ }
+ 
+ treeview.view.trough {
+   background: none;
+   background-color: transparent;
+   border-bottom-color: rgba($fg_color, 0.2);
+ }
+ 
+ treeview.view.trough:selected {
+   background: none;
+   background-color: transparent;
+   border-bottom-color: rgba($selected_fg_color, 0.2);
+ }
+ 
+ treeview.view {
+   color: $fg_color;
+   background-color: $bg_color;
+ }
+ 
+ treeview.view:selected {
+   background: none;
+   color: $selected_fg_color;
+   background-color: $selected_bg_color;
+ }
 
 // treeview.view.trough,
 // treeview.view.progressbar {

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -610,7 +610,9 @@ radio {
   }
 }
 
-// treeview.view Progressbar improvements
+/******************************************
+ * treeview.view Progressbar improvements *
+ ******************************************/
 treeview.view.trough,
 treeview.view.progressbar {
   background: none;
@@ -643,9 +645,8 @@ treeview.view.trough:selected {
 }
 
 treeview.view {
-  background: none;
   color: $fg_color;
-  background-color: transparent;
+  background-color: $bg_color;
 }
 
 treeview.view:selected {


### PR DESCRIPTION
Ensure that treview.view doesn't have a transparent background, allowing some dropdown in GNUCash to work properly.

Testing:
* Ensure that we do not see regressions related to #375  Compare behavior in System Monitor before/after
* Ensure that dropdowns in GNUCash are not transparent. See #467 for details 

(GNUCash will require creating a blank account and adding a few transactions in order to see the issue.)

Fixes #467 