### PR TITLE
Prevent Overview search entry from becoming transparent when hovered

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-gtk-theme (5.3.3) groovy; urgency=medium
+
+  * Ensure overview search entry doesn't become transparent in hover.
+
+ -- Ian Santopietro <ian@system76.com>  Mon, 25 Jan 2021 13:34:41 -0700
+
 pop-gtk-theme (5.3.2) groovy; urgency=medium
 
   * Make calendar labels more legible, especially in the dark mode

--- a/gnome-shell/src/gnome-shell-sass/widgets/_search-entry.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_search-entry.scss
@@ -13,7 +13,7 @@ $search_entry_height: 36px;
   border-color: $borders_color;
 
   &:hover {
-    background-color: $hover_bg_color;
+    background-color: $bg_color;
     border-color: $hover_borders_color;
     color: $hover_fg_color;
   }


### PR DESCRIPTION
Ensures that an opaque BG color is always set on the Overview search entry. 

Fixes #497 