### PR TITLE
Define text_view_bg

### DIFF
--- a/gtk/src/light/gtk-3.0/_colors-public.scss
+++ b/gtk/src/light/gtk-3.0/_colors-public.scss
@@ -115,3 +115,5 @@ read if you used those and something break with a version upgrade you're on your
 /* content view background such as thumbnails view in Photos or Boxes */
 @define-color content_view_bg #{"" + $base_color};
 
+/* Very contrasty background for text views (@theme_text_color foreground) */
+@define-color text_view_bg #{"" + if($variant == 'light', $base_color, darken($base_color,6%))};


### PR DESCRIPTION
Fixes https://github.com/pop-os/gtk-theme/issues/505.

Regression testing should check that this doesn't change the background colors of any other text widgets, and doesn't affect the terminal theming in Pop!_OS.