### PR TITLE
fix(apps): reimplement #513 for focal

### DIFF
--- a/gtk/src/light/gtk-3.0/_apps.scss
+++ b/gtk/src/light/gtk-3.0/_apps.scss
@@ -447,14 +447,31 @@ headerbar button image ~ window decoration ~ menu separator {
 .documents-scrolledwin.frame.frame widget flowboxchild.tile { background-color: transparent; }
 
 /***********
-  * Firefox *
-  ***********/
+ * Firefox *
+ ***********/
 #MozillaGtkWidget.background  {
-  // Removes rounded menus because the border bleeds in firefox
   // REMOVE THIS when firefox supports rounded menus
   menu, .menu,.context-menu { border-radius: 0; }
 
-  menubar, .menubar { background-color: $headerbar_bg_color; color:$headerbar_fg_color; }
+  @if ($variant == 'light') {
+    menubar,
+    .menubar,
+    menubar > menuitem:hover {
+      background-color: $headerbar_bg_color;
+      color:$headerbar_fg_color;
+    }
+  }
+
+  // Set a darker text-selection background
+  // Ideally we don't need this, but https://bugzilla.mozilla.org/show_bug.cgi?id=1703679
+  // tells Firefox to use the FG color instead of the BG color. Thus we need to 
+  // Tell Firefox that we're using a different color than we normally are.
+  // We then set the selection foreground color to be white to force Firefox
+  // to use the correct one
+  *:selected {
+    color: $white;
+    background-color: #48b9c7;
+  }
 
   // Adapt scrollbars a bit more to the GTK Scrollbar styling
   scrollbar {
@@ -475,6 +492,18 @@ headerbar button image ~ window decoration ~ menu separator {
   }
 }
 
+  normal-button {
+    @include button(normal);
+
+    &:hover {
+      @include button(hover);
+    }
+    &:active { @include button(active)}
+
+    &:disabled {@include button(insensitive);}
+  }
+
+  
 /*********************	
   * Chrome / Chromium *	
   *********************/	


### PR DESCRIPTION
See #513 

This unfortunately affects all of Firefox, so we also darken the color so enable
it to have somewhat acceptable contrast. It is confined to Firefox though.