### PR TITLE
Updated Panel Button Styling

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
@@ -64,14 +64,6 @@ $panel_icon_padding: 3px;
       padding: $base_padding - $panel_icon_padding;
     }
 
-    // // app menu icon
-    // .app-menu-icon {
-    //   margin-left: $base_margin;
-    //   margin-right: $base_margin;
-    //   -st-icon-style: symbolic;
-    //   // dimensions of the icon are hardcoded
-    // }
-
     // lock & login screen styles
     .unlock-screen &,
     .login-screen & {

--- a/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
@@ -4,7 +4,7 @@
 $panel_corner_radius: $base_border_radius+1;
 $panel_fg_color: #ccc;
 $panel_height: 1.86em;
-$panel_button_margin: 2px;
+$panel_button_margin: 3px;
 $panel_icon_padding: 3px;
 
 
@@ -41,8 +41,7 @@ $panel_icon_padding: 3px;
 
   // panel menus
   .panel-button {
-    margin-top: $panel_button_margin;
-    margin-bottom: $panel_button_margin;
+    border: $panel_button_margin solid $panel_bg_color;
     border-radius: 9999px;
     font-weight: bold;
     color: $panel_fg_color;

--- a/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
@@ -6,6 +6,7 @@ $panel_fg_color: #ccc;
 $panel_height: 1.86em;
 $panel_button_margin: 3px;
 $panel_icon_padding: 3px;
+$lock_panel_shadow: 0px 0px 10px 1px black;
 
 
 #panel {
@@ -26,14 +27,24 @@ $panel_icon_padding: 3px;
     }
 
     .panel-button {
+      text-shadow: $lock_panel_shadow;
+      
       color: $panel_fg_color;
       border-color: transparent;
       border-width: 0;
+
+      StIcon{
+        icon-shadow: $lock_panel_shadow;
+      }
 
       &:focus, &:hover, &:active { 
         color: white; 
         border-color: transparent;
         border-width: 0;
+      }
+
+      &:active {
+        background-color: rgba($panel_fg_color, 0.2);
       }
     }
   }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
@@ -63,22 +63,44 @@ $lock_panel_shadow: 0px 0px 10px 1px black;
 
   // panel menus
   .panel-button {
-    border: $panel_button_margin solid transparent; //"crops" the "background"
+    border: $panel_button_margin solid transparent; // "crops" the "background"
     border-radius: 99px;
     font-weight: bold;
     color: $panel_fg_color;
     -natural-hpadding: $base_padding * 2;
     -minimum-hpadding: $base_padding;
 
+    &.clock-display {
+      .clock {
+        padding: 0 10px;
+        border: $panel_button_margin solid transparent;
+        border-radius: 99px;
+      }
+    }
+
     &:hover {
       color: lighten($panel_fg_color, 20%);
     }
 
     &:active, &:overview, &:focus, &:checked {
+      // Trick due to St limitations. It needs a background to draw a box-shadow
       background-color: rgba($panel_fg_color, 0.01);
       color: lighten($panel_fg_color, 20%);
       box-shadow: inset 0 0 0 100px rgba($panel_fg_color, 0.3);
+
+      &.clock-display {
+        background: none;
+        box-shadow: none;
+
+        .clock {
+          background-color: rgba($panel_fg_color, 0.01);
+          color: lighten($panel_fg_color, 20%);
+          box-shadow: inset 0 0 0 100px rgba($panel_fg_color, 0.3);
+        }
+      }
     }
+
+
 
     // status area icons
     .system-status-icon {

--- a/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
@@ -28,7 +28,6 @@ $lock_panel_shadow: 0px 0px 10px 1px black;
 
     .panel-button {
       text-shadow: $lock_panel_shadow;
-      
       color: $panel_fg_color;
       border-color: transparent;
       border-width: 0;
@@ -64,8 +63,8 @@ $lock_panel_shadow: 0px 0px 10px 1px black;
 
   // panel menus
   .panel-button {
-    border: $panel_button_margin solid transparent;
-    border-radius: 9999px;
+    border: $panel_button_margin solid transparent; //"crops" the "background"
+    border-radius: 99px;
     font-weight: bold;
     color: $panel_fg_color;
     -natural-hpadding: $base_padding * 2;
@@ -76,9 +75,9 @@ $lock_panel_shadow: 0px 0px 10px 1px black;
     }
 
     &:active, &:overview, &:focus, &:checked {
-      border-color: $panel_bg_color;
+      background-color: rgba($panel_fg_color, 0.01);
       color: lighten($panel_fg_color, 20%);
-      background-color: rgba($panel_fg_color, 0.3);
+      box-shadow: inset 0 0 0 100px rgba($panel_fg_color, 0.3);
     }
 
     // status area icons

--- a/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
@@ -25,27 +25,6 @@ $lock_panel_shadow: 0px 0px 10px 1px black;
       -panel-corner-background-color: transparent;
       -panel-corner-border-color: transparent;
     }
-
-    .panel-button {
-      text-shadow: $lock_panel_shadow;
-      color: $panel_fg_color;
-      border-color: transparent;
-      border-width: 0;
-
-      StIcon{
-        icon-shadow: $lock_panel_shadow;
-      }
-
-      &:focus, &:hover, &:active { 
-        color: white; 
-        border-color: transparent;
-        border-width: 0;
-      }
-
-      &:active {
-        background-color: rgba($panel_fg_color, 0.2);
-      }
-    }
   }
 
   // spacing between activities, app menu and such

--- a/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
@@ -4,6 +4,8 @@
 $panel_corner_radius: $base_border_radius+1;
 $panel_fg_color: #ccc;
 $panel_height: 1.86em;
+$panel_button_margin: 2px;
+$panel_icon_padding: 3px;
 
 
 #panel {
@@ -35,14 +37,13 @@ $panel_height: 1.86em;
     -panel-corner-background-color: $panel_bg_color;
     -panel-corner-border-width: 2px;
     -panel-corner-border-color: transparent;
-
-    &:active, &:overview, &:focus {
-      -panel-corner-border-color: lighten($entry_color,5%);
-    }
   }
 
   // panel menus
   .panel-button {
+    margin-top: $panel_button_margin;
+    margin-bottom: $panel_button_margin;
+    border-radius: 9999px;
     font-weight: bold;
     color: $panel_fg_color;
     -natural-hpadding: $base_padding * 2;
@@ -54,21 +55,22 @@ $panel_height: 1.86em;
 
     &:active, &:overview, &:focus, &:checked {
       color: lighten($panel_fg_color, 20%);
+      background-color: rgba($panel_fg_color, 0.3);
     }
 
     // status area icons
     .system-status-icon {
       icon-size: $base_icon_size;
-      padding: $base_padding - 1px;
+      padding: $base_padding - $panel_icon_padding;
     }
 
-    // app menu icon
-    .app-menu-icon {
-      margin-left: $base_margin;
-      margin-right: $base_margin;
-      -st-icon-style: symbolic;
-      // dimensions of the icon are hardcoded
-    }
+    // // app menu icon
+    // .app-menu-icon {
+    //   margin-left: $base_margin;
+    //   margin-right: $base_margin;
+    //   -st-icon-style: symbolic;
+    //   // dimensions of the icon are hardcoded
+    // }
 
     // lock & login screen styles
     .unlock-screen &,
@@ -80,21 +82,7 @@ $panel_height: 1.86em;
 
   .panel-button {
     &:active, &:overview, &:focus, &:checked {
-      // Trick due to St limitations. It needs a background to draw a box-shadow
-      background-color: rgba(0, 0, 0, 0.01);
-      box-shadow: inset 0 -2px 0 0 lighten($entry_color,5%);
-    }
-  }
-
-  .panel-button.clock-display {
-    // Move highlight from .panel-button to .clock
-    &:active, &:overview, &:focus, &:checked {
-      box-shadow: none;
-
-      .clock {
-        background-color: rgba(0, 0, 0, 0.01);
-        box-shadow: inset 0 -2px 0 0 lighten($entry_color,5%);
-      }
+      
     }
   }
 

--- a/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
@@ -24,6 +24,18 @@ $panel_icon_padding: 3px;
       -panel-corner-background-color: transparent;
       -panel-corner-border-color: transparent;
     }
+
+    .panel-button {
+      color: $panel_fg_color;
+      border-color: transparent;
+      border-width: 0;
+
+      &:focus, &:hover, &:active { 
+        color: white; 
+        border-color: transparent;
+        border-width: 0;
+      }
+    }
   }
 
   // spacing between activities, app menu and such
@@ -41,7 +53,7 @@ $panel_icon_padding: 3px;
 
   // panel menus
   .panel-button {
-    border: $panel_button_margin solid $panel_bg_color;
+    border: $panel_button_margin solid transparent;
     border-radius: 9999px;
     font-weight: bold;
     color: $panel_fg_color;
@@ -53,6 +65,7 @@ $panel_icon_padding: 3px;
     }
 
     &:active, &:overview, &:focus, &:checked {
+      border-color: $panel_bg_color;
       color: lighten($panel_fg_color, 20%);
       background-color: rgba($panel_fg_color, 0.3);
     }
@@ -61,19 +74,6 @@ $panel_icon_padding: 3px;
     .system-status-icon {
       icon-size: $base_icon_size;
       padding: $base_padding - $panel_icon_padding;
-    }
-
-    // lock & login screen styles
-    .unlock-screen &,
-    .login-screen & {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
-    }
-  }
-
-  .panel-button {
-    &:active, &:overview, &:focus, &:checked {
-      
     }
   }
 


### PR DESCRIPTION
Update Panel button styling to match the latest mockups.

Should give all of the panel buttons a pill style when active similar to the current style for the Workspaces and Applications buttons.