### PR TITLE
Added ability to set a background image in gdm.

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_screen-shield.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_screen-shield.scss
@@ -66,8 +66,14 @@
 }
 
 #lockDialogGroup {
-  background-color: $gdm_grey;
+  background-color: $gdm_grey; 
+  background-image: url('file:///etc/gdm3/gdm-background');
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-position: center;
 }
+
 
 #unlockDialogNotifications {
   StButton#vhandle, StButton#hhandle {
@@ -76,3 +82,6 @@
     &:active { background-color: transparentize($selected_bg_color,0.5); }
   }
 }
+
+
+

--- a/gnome-shell/src/meson.build
+++ b/gnome-shell/src/meson.build
@@ -149,16 +149,14 @@ foreach variant: variants
   install_data(data_sources, install_dir: install_dir)
 endforeach
 
-if gnomeshell_use_gresource
-  gnome.compile_resources(
-    'gnome-shell-theme',
-    gresource_xml,
-    dependencies: theme_css,
-    gresource_bundle: true,
-    install: true,
-    install_dir: gnomeshell_theme_dir,
+gnome.compile_resources(
+  'gnome-shell-theme',
+  gresource_xml,
+  dependencies: theme_css,
+  gresource_bundle: true,
+  install: true,
+  install_dir: gnomeshell_theme_dir,
 )
-else
-  # Symlink default variant
-  meson.add_install_script('install-shell.sh', meson.project_name())
-endif
+
+# Symlink default variant
+meson.add_install_script('install-shell.sh', meson.project_name())


### PR DESCRIPTION
Adds ability to set the background to an image stored as or linked to /etc/gdm3/gdm-background
Removes gnomeshell_use_gresource check from meson_build to ensure that the resource file (needed by GDM3) is created. 

This PR doesn't include a gdm-background image. 