### PR TITLE
Support gdm-theme.gresource alternative

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-gtk-theme (5.4.2) impish; urgency=medium
+
+  * Support gdm-theme.gresource alternative
+
+ -- Jeremy Soller <jeremy@system76.com>  Wed, 11 Aug 2021 09:26:46 -0600
+
 pop-gtk-theme (5.4.1) hirsute; urgency=medium
 
   * FIX: Ensure that the dark theme is packaged in the GResource file.

--- a/debian/pop-gnome-shell-theme.postinst
+++ b/debian/pop-gnome-shell-theme.postinst
@@ -4,8 +4,8 @@ set -e
 
 if [ "$1" = configure ]; then
   update-alternatives --install \
-    /usr/share/gnome-shell/gdm3-theme.gresource \
-    gdm3-theme.gresource \
+    /usr/share/gnome-shell/gdm-theme.gresource \
+    gdm-theme.gresource \
     /usr/share/gnome-shell/theme/Pop/gnome-shell-theme.gresource \
     20
 fi

--- a/debian/pop-gnome-shell-theme.preinst
+++ b/debian/pop-gnome-shell-theme.preinst
@@ -3,8 +3,14 @@
 set -e
 
 if [ "$1" = "upgrade" ]; then
+  # Remove older deprecated themes. Can be removed post 21.04
+  if dpkg --compare-versions "$2" lt-nl "5.4.2~"; then
+    update-alternatives --remove gdm3-theme.gresource \
+      /usr/share/gnome-shell/theme/Pop/gnome-shell-theme.gresource || true
+  fi
+
   # Remove older deprecated themes. Can be removed post 20.04
-  if dpkg --compare-versions "$2" lt-nl 5.1.1; then
+  if dpkg --compare-versions "$2" lt-nl "5.1.1~"; then
     update-alternatives --remove gdm3.css \
       /usr/share/gnome-shell/theme/pop-dark.css || true
   fi

--- a/debian/pop-gnome-shell-theme.prerm
+++ b/debian/pop-gnome-shell-theme.prerm
@@ -3,7 +3,7 @@
 set -e
 
 if [ "$1" = "remove" ]; then
-  update-alternatives --remove gdm3-theme.gresource \
+  update-alternatives --remove gdm-theme.gresource \
     /usr/share/gnome-shell/theme/Pop/gnome-shell-theme.gresource
 fi
 

--- a/gnome-shell/src/data/gnome-shell-theme.gresource.xml
+++ b/gnome-shell/src/data/gnome-shell-theme.gresource.xml
@@ -13,7 +13,7 @@
     <file>gnome-shell-high-contrast.css</file>
     <file>gnome-shell-dark.css</file>
     <file>gnome-shell-high-contrast-dark.css</file>
-    <file alias="gdm3.css">gnome-shell-dark.css</file>
+    <file alias="gdm.css">gnome-shell-dark.css</file>
     <file>gnome-shell-start.svg</file>
     <file alias="icons/scalable/status/message-indicator-symbolic.svg">message-indicator-symbolic.svg</file>
     <file>no-events.svg</file>


### PR DESCRIPTION
This makes the login screen themed with the Pop-dark GNOME Shell theme on 21.10.