### PR TITLE
Granite: add missing variables to fix AppCenter upstream

### DIFF
--- a/gtk/src/light/gtk-3.0/granite/_accent.scss
+++ b/gtk/src/light/gtk-3.0/granite/_accent.scss
@@ -6,6 +6,8 @@
  * File credits: Ian Santopietro <isantop@gmail.com>
  */
 
+@define-color accent_color #{"" + $text_blue};
+
 .accent {
   color: $text_blue;
 }

--- a/gtk/src/light/gtk-3.0/granite/_palette.scss
+++ b/gtk/src/light/gtk-3.0/granite/_palette.scss
@@ -81,4 +81,6 @@
  
 /* Basic UI define */
 
+@define-color bg_color #{"" + $bg_color};
 @define-color fg_color #{"" + $fg_color};
+@define-color text_color #{"" + $fg_color};


### PR DESCRIPTION
Fixes the specific issue raised in #541, though it doesn't add the entire accent palette.

![Screenshot from 2021-09-16 12-02-57@2x](https://user-images.githubusercontent.com/611168/133663117-830131dd-c8f7-458e-998f-627ec5ab7f65.png)

![Screenshot from 2021-09-16 12-03-03@2x](https://user-images.githubusercontent.com/611168/133663120-fc441592-0e84-4a33-be76-7e7a792363ce.png)

Exact color definitions are up to you, but I tried to use what made sense from what is already present.