### PR TITLE
fix(shell): fix blue selected user background in Login Screen

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
@@ -113,7 +113,7 @@
 .login-dialog-user-list {
   spacing: 12px;
   width: 23em;
-  &:expanded .login-dialog-user-list-item:selected { background-color: $selected_bg_color; color: $selected_fg_color; }
+  &:expanded .login-dialog-user-list-item:selected { background-color: rgba($osd_fg_color, 0.1); color: $selected_fg_color; }
   &:expanded .login-dialog-user-list-item:logged-in { border-right: 2px solid $selected_bg_color; }
 }
 
@@ -128,7 +128,7 @@
     margin-top: 6px;
     background-color: $osd_fg_color;
   }
-  &:focus .login-dialog-timed-login-indicator { background-color: $selected_fg_color; }
+  &:focus .login-dialog-timed-login-indicator { background-color: $orange; }
 }
 
 .user-widget-label {


### PR DESCRIPTION
Corrects the (low-contrast) blue background for the selected user in the login screen and swaps it to more closely match the color used in 21.04.

Fixes #539 