### PR TITLE
fix(shell): change slider handle color to match trough

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
@@ -19,9 +19,9 @@ $slider_size: 15px;
   // slider handler
   -slider-handle-radius: $slider_size * 0.5; // half the size of the size
   -slider-handle-border-width: 1px;
-  -slider-handle-border-color: if($variant == 'light', $borders_color, $fg_color);
+  -slider-handle-border-color: $selected_bg_color;
 
-  color: if($variant == 'light', lighten($bg_color, 10%), $fg_color);
-  &:hover { color: $hover_bg_color; }
-  &:active { color: $active_bg_color; }
+  color: $selected_bg_color;
+  &:hover { color: $selected_bg_color; }
+  &:active { color: $selected_bg_color; }
 }


### PR DESCRIPTION
This better matches our GTK Theme as well as providing better contrast
for the handle compared to the current version, which is the same as
the background color.

Before:

![image](https://user-images.githubusercontent.com/5883565/134713863-688848c4-21e1-4a0f-a6bf-7428d7e4f728.png)

After:

![image](https://user-images.githubusercontent.com/5883565/134713835-a42d99d7-87d8-46dc-a55f-724a76d83078.png)


