### PR TITLE
fix(shell): add colored focus border to Shell dialog buttons

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_drawing.scss
+++ b/gnome-shell/src/gnome-shell-sass/_drawing.scss
@@ -148,7 +148,7 @@
     color: $tc;
     text-shadow: 0 1px $text_shadow_color;
     icon-shadow: 0 1px $text_shadow_color;
-    box-shadow: inset 0 0 0 2px transparentize($c, 0.4);
+    box-shadow: inset 0 0 0 2px transparentize($entry_color, 0.4);
     //border-color: $selected_bg_color;
   }
 


### PR DESCRIPTION
Currently, focused buttons in shell have very poor contrast with unfocused button, which can be a huge problem for users without use of a mouse. Previous shell themes used a colored border around the buttons which indicates where the focus is at. This restores this border, which improves usability and accessibility of the shell theme.