### PR TITLE
Fix panel color with pop-os/comsic-workspaces#34

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
@@ -2,7 +2,7 @@
 // a.k.a. the panel
 
 $panel_corner_radius: $base_border_radius+1;
-$panel_bg_color: #000;
+$panel_bg_color: #211F1F;
 $panel_fg_color: #ddd;
 $panel_height: 2.2em;
 $panel_transition_duration: 250ms; // same as the overview transition duration


### PR DESCRIPTION
pop-os/cosmic-workspaces#34 fixes bugs, but does so by removing the CSS in the extension, which requires that we move the themeing here.

I wasn't able to get the themeing fix to work locally without having to install the [User Themes](https://extensions.gnome.org/extension/19/user-themes/) extension first. But I am hoping that by having this build it will install differently than my build locally.