### PR TITLE
fix(gtk/apps): ensure that Calendar labels without backgrounds are readable

### DIFF
--- a/gtk/src/light/gtk-3.0/_apps.scss
+++ b/gtk/src/light/gtk-3.0/_apps.scss
@@ -40,6 +40,10 @@ list.tweak-categories separator {
   color: $fg_color;
 }
 
+.color-dark.horizontal.timed > stack > grid > label {
+  color: $fg_color;
+}
+
 /***********
 * Nautilus *
 ***********/


### PR DESCRIPTION
#488 introduced a bug in the light theme which caused some events in the Calendar to be rendered with white text on a white background. This change fixes this so that events without a background are always rendered using the foreground color, which will always contrast with the background color.