### PR TITLE
fix(shell): fix screenshot UI contrast

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+pop-gtk-theme (5.5.1) jammy; urgency=medium
+
+  * Fixes for screenshot UI
+  * Unlock dialog entry improvements
+  * Tweaks to GDM color to ensure matches with Plymouth
+  * Login screen user selection background
+  * Shell popover submenu fixes
+  * Sync GTK Theme base with upstream
+  * Fixes for  Nautilus styling
+  * Text color improvements for Calendar
+
+ -- Ian Santopietro <ian@system76.com>  Tue, 05 Apr 2022 10:38:00 -0600
+
 pop-gtk-theme (5.5.0) jammy; urgency=medium
 
   * Updates for GNOME 42

--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -1,7 +1,7 @@
 // When color definition differs for dark and light variant,
 // it gets @if ed depending on $variant
 @import "ubuntu-colors";
-@import "pop_os_colors";
+@import "pop-os-colors";
 
 $base_color: if($variant == 'light', #ffffff, #36322F); 
 $text_color: if($variant == 'light', black, white);
@@ -37,7 +37,9 @@ $tooltip_borders_color: $osd_outer_borders_color;
 $shadow_color: if($variant == 'light', rgba(0,0,0,0.1), rgba(0,0,0,0.2));
 
 // overview background color
-$system_bg_color: $base_color;
+// $system_bg_color: $base_color;
+
+$system_bg_color: #36322f; //previously "gdm_grey"
 
 //insensitive state derived colors
 $insensitive_fg_color: mix($fg_color, $bg_color, 50%);

--- a/gnome-shell/src/gnome-shell-sass/_high-contrast-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_high-contrast-colors.scss
@@ -1,6 +1,8 @@
 // When color definition differs for dark and light variant,
 // it gets @if ed depending on $variant
 
+@import "pop-os-colors";
+
 $base_color: #222;
 $bg_color: #000;
 $fg_color: #fff;

--- a/gnome-shell/src/gnome-shell-sass/_pop-os-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_pop-os-colors.scss
@@ -90,7 +90,8 @@ $dash_bg_color: $panel_bg_color;
 $panel-alpha-value: 0.0;
 $panel_opaque_value: 0.0;
 
+$dark_fg_color: $light_ui_500;
+$light_fg_color: $dark_neutral_grey_500;
+
 $dash-alpha-value: 0.0;
 $dash-opaque-alpha-value: 0.0;
-
-$system_bg_color: #36322f; //previously "gdm_grey"

--- a/gnome-shell/src/gnome-shell-sass/widgets/_screenshot.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_screenshot.scss
@@ -11,7 +11,7 @@ $screenshot_ui_shot_cast_margin: 21px;
 $screenshot_ui_panel_border_radius: $modal_radius + $screenshot_ui_shot_cast_margin;
 $screenshot_ui_shot_cast_spacing: 3px;
 
-$screenshot_ui_button_red: $error_color;
+$screenshot_ui_button_red: #E56A54;
 
 .screenshot-ui-panel {
   @extend %osd_panel;
@@ -93,7 +93,7 @@ $screenshot_ui_button_red: $error_color;
 }
 
 .screenshot-ui-shot-cast-container {
-  background-color: transparentize($color: $hover_bg_color, $amount: 0.5);
+  background-color: lighten($osd_bg_color, 35%);
   border-radius: $modal_radius;
   padding: $screenshot_ui_shot_cast_spacing;
   spacing: $screenshot_ui_shot_cast_spacing;
@@ -104,11 +104,19 @@ $screenshot_ui_button_red: $error_color;
 }
 
 .screenshot-ui-shot-cast-button {
+  color: white !important;
   padding: $base_padding $base_padding*2;
   background-color: transparent;
-  &:hover, &:focus { background-color: lighten($hover_bg_color, 5%); }
-  &:active { background-color: lighten($active_bg_color,5%); }
-  &:checked { background-color: white; color: black; }
+  &:hover, &:focus {
+    background-color: lighten($osd_bg_color, 50%);
+  }
+  &:active {
+    background-color: lighten($osd_bg_color, 40%);
+  }
+  &:checked {
+    background-color: white; 
+    color: black !important;
+  }
 
   border-radius: $modal_radius - $screenshot_ui_shot_cast_spacing;
 

--- a/gnome-shell/src/gnome-shell-sass/widgets/_screenshot.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_screenshot.scss
@@ -45,6 +45,9 @@ $screenshot_ui_button_red: #E56A54;
   &:active {
     background-color: transparentize($color: $dark_fg_color, $amount: 0.7) !important;
   }
+  &:insensitive {
+    color: transparentize($color: $osd_fg_color, $amount: 0.8) !important;
+  }
 }
 
 .screenshot-ui-capture-button {

--- a/gnome-shell/src/gnome-shell-sass/widgets/_screenshot.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_screenshot.scss
@@ -34,6 +34,17 @@ $screenshot_ui_button_red: $error_color;
   @extend %osd_button;
   padding: $base_padding * 2 $base_padding * 3 !important;
   border-radius: $screenshot_ui_panel_border_radius - $screenshot_ui_panel_padding;
+  color: $dark_fg_color !important;
+
+  &:hover, &:focus, &:checked {
+    background-color: transparentize($color: $dark_fg_color, $amount: 0.85) !important;
+  }
+  &:checked:hover {
+    background-color: transparentize($dark_fg_color, 0.5) !important;
+  }
+  &:active {
+    background-color: transparentize($color: $dark_fg_color, $amount: 0.7) !important;
+  }
 }
 
 .screenshot-ui-capture-button {
@@ -52,13 +63,13 @@ $screenshot_ui_button_red: $error_color;
 
   &:hover, &:focus {
     .screenshot-ui-capture-button-circle {
-      background-color: darken($osd_fg_color, 15%);
+      background-color: lighten($osd_fg_color, 15%);
     }
   }
 
   &:active {
     .screenshot-ui-capture-button-circle {
-      background-color: darken($osd_fg_color, 50%);
+      background-color: lighten($osd_fg_color, 50%);
     }
   }
 
@@ -82,10 +93,11 @@ $screenshot_ui_button_red: $error_color;
 }
 
 .screenshot-ui-shot-cast-container {
-  background-color: $hover_bg_color;
+  background-color: transparentize($color: $hover_bg_color, $amount: 0.5);
   border-radius: $modal_radius;
   padding: $screenshot_ui_shot_cast_spacing;
   spacing: $screenshot_ui_shot_cast_spacing;
+  color: $light_fg_color;
 
   &:ltr { margin-left: $screenshot_ui_shot_cast_margin - $screenshot_ui_panel_padding; }
   &:rtl { margin-right: $screenshot_ui_shot_cast_margin - $screenshot_ui_panel_padding; }
@@ -108,6 +120,17 @@ $screenshot_ui_button_red: $error_color;
   border-radius: 99px;
   padding: $base_padding * 2 !important;
   StIcon { icon-size: $base_icon_size; }
+  color: $dark_fg_color !important;
+
+  &:hover, &:focus, &:checked {
+    background-color: transparentize($color: $dark_fg_color, $amount: 0.85) !important;
+  }
+  &:checked:hover {
+    background-color: transparentize($dark_fg_color, 0.5) !important;
+  }
+  &:active {
+    background-color: transparentize($color: $dark_fg_color, $amount: 0.7) !important;
+  }
 }
 
 .screenshot-ui-area-indicator-shade {


### PR DESCRIPTION
The active and hovered buttons in the new screenshot UI were very
low-contrast; this improves the contrast of the icons and button
backgrounds to be easier to see against a wide variety of layers
underneath.