### PR TITLE
fix(shell): Use dark background for shell popovers in dark mode

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_popovers.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_popovers.scss
@@ -93,7 +93,7 @@
 
 // popover submenus
 .popup-sub-menu {
-  background-color: $checked_bg_color;
+  background-color: darken($bg_color, 5%);
   border-radius: 0 0 $base_border_radius $base_border_radius;
 
   .popup-menu-ornament {


### PR DESCRIPTION
As requested by @WatchMkr 