### PR TITLE
Fix missing event dots in GNOME Shell light theme

### DIFF
--- a/gnome-shell/src/calendar-today-light.svg
+++ b/gnome-shell/src/calendar-today-light.svg
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="24"
+   height="24"
+   id="svg10621"
+   version="1.1"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="calendar-today-light.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs10623">
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient34508-1-3"
+       id="radialGradient99561-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72146227,0,0,0.27484277,14.205424,21.754717)"
+       cx="51"
+       cy="30"
+       fx="51"
+       fy="30"
+       r="42" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient34508-1-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop34510-1-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop34512-4-5" />
+    </linearGradient>
+    <radialGradient
+       r="42"
+       fy="30"
+       fx="51"
+       cy="30"
+       cx="51"
+       gradientTransform="matrix(0.72146227,0,0,0.27484277,14.205424,21.754717)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient10592"
+       xlink:href="#linearGradient34508-1-3"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient34508-1-3"
+       id="radialGradient3770"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72146227,0,0,0.27484277,14.205424,21.754717)"
+       cx="51"
+       cy="30"
+       fx="51"
+       fy="30"
+       r="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient34508-1-3"
+       id="radialGradient3001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72146227,0,0,0.27484277,14.205424,21.754717)"
+       cx="51"
+       cy="30"
+       fx="51"
+       fy="30"
+       r="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient34508-1-3"
+       id="radialGradient3007"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72146227,0,0,0.27484277,14.205424,21.754717)"
+       cx="51"
+       cy="30"
+       fx="51"
+       fy="30"
+       r="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient34508-1-3"
+       id="radialGradient3067"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72146227,0,0,0.27484277,14.205424,21.754717)"
+       cx="51"
+       cy="30"
+       fx="51"
+       fy="30"
+       r="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient34508-1-3"
+       id="radialGradient3072"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72146227,0,0,0.27484277,14.205424,21.754717)"
+       cx="51"
+       cy="30"
+       fx="51"
+       fy="30"
+       r="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient34508-1-3"
+       id="radialGradient2997"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72146227,0,0,0.27484277,14.205424,21.754717)"
+       cx="51"
+       cy="30"
+       fx="51"
+       fy="30"
+       r="42" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#000000"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.107234"
+     inkscape:cx="11.838456"
+     inkscape:cy="18.356257"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3109"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata10626">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-469.08263,-537.99307)">
+    <circle
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#63b1bc;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="path7305"
+       cx="481.57138"
+       cy="559.4649"
+       r="1.5" />
+  </g>
+</svg>

--- a/gnome-shell/src/data/gnome-shell-theme.gresource.xml
+++ b/gnome-shell/src/data/gnome-shell-theme.gresource.xml
@@ -2,6 +2,7 @@
 <gresources>
   <gresource prefix="/org/gnome/shell/theme">
     <file>calendar-today.svg</file>
+    <file>calendar-today-light.svg</file>
     <file alias="icons/scalable/status/carousel-arrow-next-24-symbolic.svg">carousel-arrow-next-24-symbolic.svg</file>
     <file alias="icons/scalable/status/carousel-arrow-back-24-symbolic.svg">carousel-arrow-back-24-symbolic.svg</file>
     <file>checkbox-focused.svg</file>


### PR DESCRIPTION
Adds missing Calendar dots to light GNOME Shell theme. This will ensure that the dots show up when the light theme is in use. 

Fixes #582 