### PR TITLE
fix(colors): fix incorrect active scrollbar bg color

### DIFF
--- a/gtk/src/light/gtk-3.0/_colors-pop.scss
+++ b/gtk/src/light/gtk-3.0/_colors-pop.scss
@@ -35,3 +35,4 @@ $checkradio_bg_color: if($variant=='light', #FFAD00, #FBB86C);
 $checkradio_fg_color: #000;
 $checkradio_borders_color: $checkradio_bg_color;
 $spinner_fg_color: $fg_color;
+$scrollbar_slider_active_color: darken($selected_bg_color, 5%);


### PR DESCRIPTION
The color was coming from Adwaita, instead of from Pop. This updates it to grab the correct color blue instead.

Fixes #590