### PR TITLE
Nautilus Pathbar Overhaul

### DIFF
--- a/gtk/src/light/gtk-3.0/_apps.scss
+++ b/gtk/src/light/gtk-3.0/_apps.scss
@@ -131,9 +131,11 @@ list.tweak-categories separator {
       border-width: 1px;
       border-style: solid;
       border-right-width: 0;
+      transition: 200ms ease-out;
 
-      &.backdrop {
+      &:backdrop {
         @include button(backdrop, $backdrop_headerbar_bg_color, $backdrop_headerbar_fg_color);
+        border-color: $_btn_backdrop_border;
       }
 
       viewport, viewport box {

--- a/gtk/src/light/gtk-3.0/_apps.scss
+++ b/gtk/src/light/gtk-3.0/_apps.scss
@@ -125,18 +125,28 @@ list.tweak-categories separator {
 
   .nautilus-path-bar {
     > scrolledwindow {
+      @include button(normal, $_headerbar_button_bg, $headerbar_fg_color);
       margin: 6px 0px 6px 0px;
-      border-radius: 6px 0px 0px 6px;
-      border-right-width: 0px;
-      background-color: $_headerbar_button_bg;
+      border-radius: 4px 0px 0px 4px;
+      border-width: 1px;
+      border-style: solid;
+      border-right-width: 0;
+
+      &.backdrop {
+        @include button(backdrop, $backdrop_headerbar_bg_color, $backdrop_headerbar_fg_color);
+      }
+
+      viewport, viewport box {
+        border: none;
+        box-shadow: none;
+        background: none;
+      }
 
       undershoot.left {
         border-radius: 5px;
-        margin-left: 1px;
         background: linear-gradient(to right, rgba($_headerbar_button_bg, 0.9) 4px, rgba($_headerbar_button_bg, 0.0) 24px);
       }
       undershoot.right {
-        margin-right: 1px;
         background: linear-gradient(to left, rgba($_headerbar_button_bg, 0.9) 4px, rgba($_headerbar_button_bg, 0.0) 24px);
       }
     

--- a/gtk/src/light/gtk-3.0/_apps.scss
+++ b/gtk/src/light/gtk-3.0/_apps.scss
@@ -130,7 +130,6 @@ list.tweak-categories separator {
       border-radius: 4px 0px 0px 4px;
       border-width: 1px;
       border-style: solid;
-      border-right-width: 0;
       transition: 200ms ease-out;
 
       &:backdrop {
@@ -156,6 +155,10 @@ list.tweak-categories separator {
     
     > button {
       margin: 0;
+
+      &.toggle {
+        border-left-width: 0;
+      }
     }
 
     .path-buttons-box {

--- a/gtk/src/light/gtk-3.0/_apps.scss
+++ b/gtk/src/light/gtk-3.0/_apps.scss
@@ -131,12 +131,15 @@ list.tweak-categories separator {
       background-color: $_headerbar_button_bg;
 
       undershoot.left {
-        border-radius: 6px 0px 0px 6px;
-        background: linear-gradient(to right, $_headerbar_button_bg 6px, $_headerbar_button_bg 24px);
+        border-radius: 5px;
+        margin-left: 1px;
+        background: linear-gradient(to right, rgba($_headerbar_button_bg, 0.9) 4px, rgba($_headerbar_button_bg, 0.0) 24px);
       }
       undershoot.right {
-        background: linear-gradient(to left, $_headerbar_button_bg 6px, $_headerbar_button_bg 24px);
+        margin-right: 1px;
+        background: linear-gradient(to left, rgba($_headerbar_button_bg, 0.9) 4px, rgba($_headerbar_button_bg, 0.0) 24px);
       }
+    
     }
     
     > button {


### PR DESCRIPTION
Revamps the styling for the Nautilus path bar to correctly styling the underflow elements and better align the visual style of the widget. 

Before, the underflow elements for the scrolled window in the pathbar were being drawn with a solid color, which means they cover up items within the pathbar. This changes the styling to make items in the pathbar appear to smoothly fade out into the edges of the pathbar when it is too long to contain every item inside it.

In addition to fixing the underflow styling error and rectangular corners present in #603, this also squares off the corners on the right-hand side of the path bar to allow it to visually flow into the context toggle button; previously the bar remained rounded, which looked bad next to the toggle button. This also fixes the double-border between the items.

Before: 
![image](https://github.com/pop-os/gtk-theme/assets/5883565/d6e03093-c493-44fd-a987-d76c83dfc33f)


After:
![image](https://github.com/pop-os/gtk-theme/assets/5883565/7226237a-7376-4b0e-b416-77416d4aa6da)


Known Issues: 

There are small visual artifacts in the left two corners of the path bar when the underflow is active and a button running off the edge of the pathbar is hovered. This appears to be an issue with the underflow rendering in GTK, and not something which can be addressed in the theme. However, this is also an uncommon issue to have happen in the first place, so I don't believe it should block this release.

Fixes #603